### PR TITLE
Update SQSAdapter to return messages that fail during crawling

### DIFF
--- a/applications/crawl/functions/crawl-urls/adapters/SQSAdapter.ts
+++ b/applications/crawl/functions/crawl-urls/adapters/SQSAdapter.ts
@@ -37,7 +37,16 @@ class SQSAdapter implements PrimarySQSAdapter {
             }
 
             try {
-                await this.crawler.crawl(url, validatedBody.depth);
+                const success = await this.crawler.crawl(
+                    url, 
+                    validatedBody.depth
+                );
+
+                if (!success) {
+                    failedCrawls.push({ 
+                        itemIdentifier: record.messageId
+                    });
+                }
             } catch (ex) {
                 console.error(
                     `Error occured during crawl: ${JSON.stringify(ex)}`


### PR DESCRIPTION
Resolves #66 

# What

Updated SQSAdapter to return message IDs in batch response if crawl fails

# Why

To enable failed crawls to be retried later