### PR TITLE
hotfix/openapi missing resource

### DIFF
--- a/services/keyphrase/keyphrase-openapi.yml
+++ b/services/keyphrase/keyphrase-openapi.yml
@@ -26,7 +26,7 @@ components:
       httpMethod: "POST"
       uri:
         Fn::GetAtt:
-        - "KeyphrasesCRUDFunction"
+        - "KeyphrasesCRUD"
         - "Arn"
       credentials:
         Fn::GetAtt:


### PR DESCRIPTION

# What

Fix issue with openapi definition for keyphrase service where the route integration was referring to an unknown resource

# Why

Currently unable to deploy the keyphrase service on master