### PR TITLE
hotfix/ci-user-missing-step-function-role

### DIFF
--- a/templates/buzzword-ci-users-template.yml
+++ b/templates/buzzword-ci-users-template.yml
@@ -37,6 +37,7 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
         - arn:aws:iam::aws:policy/AmazonSNSFullAccess
         - arn:aws:iam::aws:policy/IAMFullAccess
+        - arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess
 Outputs:
   DeployRoleARN: 
     Description: The ARN of the deployment role required to deploy stacks


### PR DESCRIPTION
# What

Updated buzzword-ci-users template to include aws step function full access policy for deploy user

# Why

Master build deployment failed due to being unable to deploy state machine resources