### PR TITLE
hotfix/ci-user-missing-event-bridge-policy

### DIFF
--- a/templates/buzzword-ci-users-template.yml
+++ b/templates/buzzword-ci-users-template.yml
@@ -27,6 +27,23 @@ Resources:
           Condition:
             StringLike:
               token.actions.githubusercontent.com:sub: !Sub repo:${GithubOrganisation}/${RepositoryName}:*
+      Policies:
+        - PolicyName: StepFunctionDeployPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - states:*
+                Effect: Allow
+                Resource: arn:aws:states:*
+        - PolicyName: EventBridgeDeployPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Action:
+                  - events:*
+                Effect: Allow
+                Resource: arn:aws:events:*
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
         - arn:aws:iam::aws:policy/AWSLambda_FullAccess
@@ -37,7 +54,6 @@ Resources:
         - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
         - arn:aws:iam::aws:policy/AmazonSNSFullAccess
         - arn:aws:iam::aws:policy/IAMFullAccess
-        - arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess
 Outputs:
   DeployRoleARN: 
     Description: The ARN of the deployment role required to deploy stacks


### PR DESCRIPTION
# What

Update buzzword-ci-users-template to include event bridge permissions
Update ci users template to start to use inline policies rather than managed

# Why

Master deployment fails without permission to deploy event bridge resources
Transferred to inline policies due to hitting the 10 managed policy limit