### PR TITLE
hotfix/oidc-provider-thumbprint-expired

### DIFF
--- a/templates/buzzword-ci-users-template.yml
+++ b/templates/buzzword-ci-users-template.yml
@@ -12,7 +12,7 @@ Resources:
       ClientIdList: 
         - sts.amazonaws.com
       ThumbprintList:
-        - a031c46782e6e6c662c2c87c76da9aa62ccabd8e
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
   DeployRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
# What

Fix certificate thumbprint in ci-users-template

# Why

The certificate used to perform OpenID connect to deploy resources to AWS had changed:
- https://github.com/aws-actions/configure-aws-credentials/issues/357