### PR TITLE
Add standard feature template for GitHub issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-template.md
+++ b/.github/ISSUE_TEMPLATE/feature-template.md
@@ -1,31 +1,30 @@
 ---
 name: Feature Template
 about: Standard issue template
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 # Value Added
 
-Provide a high level summary of the value added by doing this ticket.
+Provide a high level summary of the value added by completing this ticket.
 
 # Description
 
 Provide a more detailed account of the work involved with the ticket. Including:
-- The area the work relates to
-- A description of the work
-- Why the work is needed
-- Anything else you might think is useful
 
+-   The area the work relates to.
+-   A overall description of the work.
+-   Why the work is required.
+-   Anything else you might think is useful.
 
 # Acceptance Criteria
 
 ## AC01
 
-- Add ACs as appropriate to define the issues definition of done.
+-   Add ACs as appropriate to define the issue's definition of done.
 
 ## AC02
 
-- Add ACs as appropriate to define the issues definition of done.
+-   Add ACs as appropriate to define the issue's definition of done.


### PR DESCRIPTION
Resolves #70 

# What

Added GitHub issue template for all standard feature issues.

# Why

To ensure consistency of all tickets and reduce the effort formatting tickets