### PR TITLE
fix/deployment-appsync-permissions

### DIFF
--- a/templates/buzzword-ci-users-template.yml
+++ b/templates/buzzword-ci-users-template.yml
@@ -54,6 +54,14 @@ Resources:
                                 - route53:*
                             Effect: Allow
                             Resource: "*"
+                - PolicyName: AppSyncDeployPolicy
+                  PolicyDocument:
+                      Version: "2012-10-17"
+                      Statement:
+                          - Action:
+                                - appsync:*
+                            Effect: Allow
+                            Resource: arn:aws:appsync:*
             ManagedPolicyArns:
                 - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
                 - arn:aws:iam::aws:policy/AWSLambda_FullAccess


### PR DESCRIPTION
# What

Update `buzzword-ci-users-template.yml` to allow deployment role to create/update/delete AppSync resources

# Why

Required to make changes to the AppSync GraphQL API and corresponding resources