### PR TITLE
fix/master-keyphrase-deployment-multiple-outputs

### DIFF
--- a/scripts/deploy-keyphrase-service.sh
+++ b/scripts/deploy-keyphrase-service.sh
@@ -58,7 +58,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-crawl_event_bus_arn=$($script_dir/helpers/fetch-stack-outputs.sh -s $crawl_stack_name | jq -r .OutputValue)
+crawl_event_bus_arn=$($script_dir/helpers/fetch-stack-outputs.sh -s $crawl_stack_name | jq -r 'select ( .OutputKey == "EventBusARN" ) | .OutputValue')
 
 if [ -z $crawl_event_bus_arn ]; then
     echo "Error: No Crawl Event Bus ARN found."


### PR DESCRIPTION
# What

Update deploy-keyphrase-service.sh to filter stack output from crawl service to only event bus arn

# Why

Crawl service now has multiple outputs meaning the event bus arn was being set to multiple values where it was expected to be only one.
- Currently failing master deployments for keyphrase service
