### PR TITLE
fix/master-crawl-ui-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
         with:
             path: ./ui
         secrets:
-            deploy_role: ${{ secrets.AWS_DEPLOY_ROLE }}
-            region: ${{ secrets.CRAWL_SERVICE_ENDPOINT }}
-            crawl_service_graphql_endpoint: ${{ secrets.CRAWL_SERVICE_ENDPOINT }}
-            crawl_identity_pool_id: ${{ secrets.CRAWL_IDENTITY_POOL_ID }}
-            keyphrase_service_ws_endpoint: ${{ secrets.KEYPHRASE_WS_SERVICE_ENDPOINT }}
+            DEPLOY_ROLE: ${{ secrets.AWS_DEPLOY_ROLE }}
+            REGION: ${{ secrets.REGION }}
+            CRAWL_SERVICE_GRAPHQL_ENDPOINT: ${{ secrets.CRAWL_SERVICE_GRAPHQL_ENDPOINT }}
+            CRAWL_IDENTITY_POOL_ID: ${{ secrets.CRAWL_IDENTITY_POOL_ID }}
+            KEYPHRASE_SERVICE_WS_ENDPOINT: ${{ secrets.KEYPHRASE_SERVICE_WS_ENDPOINT }}
     validate:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -5,15 +5,15 @@ on:
                 required: true
                 type: string
         secrets:
-            deploy_role:
+            DEPLOY_ROLE:
                 required: true
-            region:
+            REGION:
                 required: true
-            crawl_service_graphql_endpoint:
+            CRAWL_SERVICE_GRAPHQL_ENDPOINT:
                 required: true
-            crawl_identity_pool_id:
+            CRAWL_IDENTITY_POOL_ID:
                 required: true
-            keyphrase_service_ws_endpoint:
+            KEYPHRASE_SERVICE_WS_ENDPOINT:
                 required: true
 
 jobs:
@@ -140,14 +140,14 @@ jobs:
             - uses: aws-actions/configure-aws-credentials@v1
               with:
                   aws-region: eu-west-2
-                  role-to-assume: ${{ secrets.deploy_role }}
+                  role-to-assume: ${{ secrets.DEPLOY_ROLE }}
             - name: Create production envfile
               uses: SpicyPizza/create-envfile@v1.3
               with:
-                  envkey_REGION: ${{ secrets.region }}
-                  envkey_CRAWL_SERVICE_GRAPHQL_ENDPOINT: ${{ secrets.crawl_service_graphql_endpoint }}
-                  envkey_CRAWL_IDENTITY_POOL_ID: ${{ secrets.crawl_identity_pool_id }}
-                  envkey_KEYPHRASE_WS_SERVICE_ENDPOINT: ${{ secrets.keyphrase_service_ws_endpoint }}
+                  envkey_REGION: ${{ secrets.REGION }}
+                  envkey_CRAWL_SERVICE_GRAPHQL_ENDPOINT: ${{ secrets.CRAWL_SERVICE_GRAPHQL_ENDPOINT }}
+                  envkey_CRAWL_IDENTITY_POOL_ID: ${{ secrets.CRAWL_IDENTITY_POOL_ID }}
+                  envkey_KEYPHRASE_WS_SERVICE_ENDPOINT: ${{ secrets.KEYPHRASE_SERVICE_WS_ENDPOINT }}
                   directory: ${{ inputs.path }}
                   file_name: .env
                   fail_on_empty: true

--- a/templates/buzzword-ci-users-template.yml
+++ b/templates/buzzword-ci-users-template.yml
@@ -62,6 +62,22 @@ Resources:
                                 - appsync:*
                             Effect: Allow
                             Resource: arn:aws:appsync:*
+                - PolicyName: CognitoDeployPolicy
+                  PolicyDocument:
+                      Version: "2012-10-17"
+                      Statement:
+                          - Action:
+                                - cognito-identity:*
+                            Effect: Allow
+                            Resource: arn:aws:cognito-identity:*
+                - PolicyName: SecretsManagerDeployPolicy
+                  PolicyDocument:
+                      Version: "2012-10-17"
+                      Statement:
+                          - Action:
+                                - secretsmanager:*
+                            Effect: Allow
+                            Resource: arn:aws:secretsmanager:*
             ManagedPolicyArns:
                 - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
                 - arn:aws:iam::aws:policy/AWSLambda_FullAccess


### PR DESCRIPTION
# What

Update buzzword-ci-users-template to allow cognito identity and secret actions during deployment
Update CI yml to fix secret mapping

# Why

Master builds for crawl service deployment were failing due to:
- Event api connection requiring the creation of secret in secrets manager (No permission granted previously)
- Identity Pool creation (No permission granted previously)

More than one secret was referring to the same value