### PR TITLE
Feature/172 persist crawl status

### DIFF
--- a/services/crawl/crawl-state-machine.asl.json
+++ b/services/crawl/crawl-state-machine.asl.json
@@ -26,7 +26,7 @@
                 {
                     "Variable": "$.recentlyCrawled",
                     "BooleanEquals": true,
-                    "Next": "Send crawl complete event"
+                    "Next": "Send crawl status update event"
                 },
                 {
                     "Variable": "$.recentlyCrawled",
@@ -34,6 +34,24 @@
                     "Next": "Send crawl started event"
                 }
             ]
+        },
+        "Send crawl status update event": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::events:putEvents",
+            "Parameters": {
+                "Entries": [
+                    {
+                        "EventBusName": "${CrawlServiceEventBusARN}",
+                        "DetailType": "Crawl Status Update",
+                        "Detail": {
+                            "baseURL.$": "$.baseURL",
+                            "status.$": "$.status"
+                        },
+                        "Source": "crawl.aws.buzzword"
+                    }
+                ]
+            },
+            "End": true
         },
         "Send crawl started event": {
             "Type": "Task",
@@ -121,24 +139,6 @@
         },
         "Crawl Failed": {
             "Type": "Fail"
-        },
-        "Send crawl complete event": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::events:putEvents",
-            "Parameters": {
-                "Entries": [
-                    {
-                        "EventBusName": "${CrawlServiceEventBusARN}",
-                        "DetailType": "Crawl Status Update",
-                        "Detail": {
-                            "baseURL.$": "$.baseURL",
-                            "status": "COMPLETE"
-                        },
-                        "Source": "crawl.aws.buzzword"
-                    }
-                ]
-            },
-            "End": true
         }
     }
 }

--- a/services/crawl/functions/crawl-urls/domain/Crawl.ts
+++ b/services/crawl/functions/crawl-urls/domain/Crawl.ts
@@ -1,4 +1,7 @@
-import { Repository } from "buzzword-aws-crawl-urls-repository-library";
+import {
+    CrawlStatus,
+    Repository,
+} from "buzzword-aws-crawl-urls-repository-library";
 import { ContentRepository } from "buzzword-aws-crawl-content-repository-library";
 
 import { CrawlerResponse, CrawlPort } from "../ports/CrawlPort";
@@ -20,6 +23,11 @@ class Crawl implements CrawlPort {
         baseURL: URL,
         maxCrawlDepth?: number
     ): Promise<CrawlerResponse> {
+        await this.urlRepository.updateCrawlStatus(
+            baseURL.hostname,
+            CrawlStatus.STARTED
+        );
+
         return new Promise((resolve) => {
             const pathnameStorages: Promise<PathnameStored>[] = [];
             this.crawler.crawl(baseURL, maxCrawlDepth).subscribe({
@@ -35,6 +43,14 @@ class Crawl implements CrawlPort {
                         pathnames,
                         pathnameStorages.length
                     );
+
+                    if (success) {
+                        await this.urlRepository.updateCrawlStatus(
+                            baseURL.hostname,
+                            CrawlStatus.COMPLETE
+                        );
+                    }
+
                     resolve({
                         success,
                         pathnames,

--- a/services/crawl/functions/crawl-urls/domain/Crawl.ts
+++ b/services/crawl/functions/crawl-urls/domain/Crawl.ts
@@ -23,11 +23,28 @@ class Crawl implements CrawlPort {
         baseURL: URL,
         maxCrawlDepth?: number
     ): Promise<CrawlerResponse> {
-        await this.urlRepository.updateCrawlStatus(
-            baseURL.hostname,
-            CrawlStatus.STARTED
-        );
+        try {
+            const statusUpdated = await this.urlRepository.updateCrawlStatus(
+                baseURL.hostname,
+                CrawlStatus.STARTED
+            );
 
+            if (statusUpdated) {
+                return this.handleCrawl(baseURL, maxCrawlDepth);
+            }
+        } catch {
+            //
+        }
+
+        return {
+            success: false,
+        };
+    }
+
+    private handleCrawl(
+        baseURL: URL,
+        maxCrawlDepth?: number
+    ): Promise<CrawlerResponse> {
         return new Promise((resolve) => {
             const pathnameStorages: Promise<PathnameStored>[] = [];
             this.crawler.crawl(baseURL, maxCrawlDepth).subscribe({

--- a/services/crawl/functions/crawl-urls/domain/__tests__/Crawl.test.ts
+++ b/services/crawl/functions/crawl-urls/domain/__tests__/Crawl.test.ts
@@ -1,6 +1,9 @@
 import { mock } from "jest-mock-extended";
 import { EMPTY, of, throwError, concat, Observable } from "rxjs";
-import { Repository } from "buzzword-aws-crawl-urls-repository-library";
+import {
+    CrawlStatus,
+    Repository,
+} from "buzzword-aws-crawl-urls-repository-library";
 import { ContentRepository } from "buzzword-aws-crawl-content-repository-library";
 
 import { CrawlerResponse } from "../../ports/CrawlPort";
@@ -17,7 +20,7 @@ const crawler = new Crawl(
 );
 
 const EXPECTED_BASE_URL_HOSTNAME = "www.example.com";
-const DEFAULT_BASE_URL = new URL(`http://${EXPECTED_BASE_URL_HOSTNAME}`);
+const DEFAULT_BASE_URL = new URL(`http://www.example.com`);
 const EXPECTED_PATHNAME = "example";
 const DEFAULT_CHILD_URL = new URL(
     `${DEFAULT_BASE_URL.toString()}${EXPECTED_PATHNAME}`
@@ -53,6 +56,22 @@ describe("crawl provides results", () => {
             expect(mockCrawlProvider.crawl).toHaveBeenCalledWith(
                 baseURL,
                 undefined
+            );
+        });
+
+        test("updates the crawl status related to the provided base URL to started and complete", () => {
+            expect(mockURLRepository.updateCrawlStatus).toHaveBeenCalledTimes(
+                2
+            );
+            expect(mockURLRepository.updateCrawlStatus).toHaveBeenNthCalledWith(
+                1,
+                EXPECTED_BASE_URL_HOSTNAME,
+                CrawlStatus.STARTED
+            );
+            expect(mockURLRepository.updateCrawlStatus).toHaveBeenNthCalledWith(
+                2,
+                EXPECTED_BASE_URL_HOSTNAME,
+                CrawlStatus.COMPLETE
             );
         });
 
@@ -115,12 +134,20 @@ describe("crawl returns no results", () => {
         response = await crawler.crawl(DEFAULT_BASE_URL);
     });
 
-    test("does not call url repository", () => {
+    test("does not store any crawled urls in the url repository", () => {
         expect(mockURLRepository.storePathname).not.toBeCalled();
     });
 
     test("does not call content repository", () => {
         expect(mockContentRepository.storePageContent).not.toBeCalled();
+    });
+
+    test("updates the crawl status to running but not complete", () => {
+        expect(mockURLRepository.updateCrawlStatus).toBeCalledTimes(1);
+        expect(mockURLRepository.updateCrawlStatus).toHaveBeenCalledWith(
+            EXPECTED_BASE_URL_HOSTNAME,
+            CrawlStatus.STARTED
+        );
     });
 
     test("returns failure", () => {
@@ -201,6 +228,16 @@ describe("Error handling", () => {
                 ).toHaveBeenCalledTimes(expectedPathnames.length);
             });
 
+            test("updates the crawl status to running but not complete", () => {
+                expect(mockURLRepository.updateCrawlStatus).toBeCalledTimes(1);
+                expect(
+                    mockURLRepository.updateCrawlStatus
+                ).toHaveBeenCalledWith(
+                    EXPECTED_BASE_URL_HOSTNAME,
+                    CrawlStatus.STARTED
+                );
+            });
+
             test("returns failure", () => {
                 expect(response.success).toBe(false);
             });
@@ -258,6 +295,16 @@ describe("Error handling", () => {
                 );
             });
 
+            test("updates the crawl status to running but not complete", () => {
+                expect(mockURLRepository.updateCrawlStatus).toBeCalledTimes(1);
+                expect(
+                    mockURLRepository.updateCrawlStatus
+                ).toHaveBeenCalledWith(
+                    EXPECTED_BASE_URL_HOSTNAME,
+                    CrawlStatus.STARTED
+                );
+            });
+
             test("returns failure", () => {
                 expect(response.success).toBe(false);
             });
@@ -307,6 +354,16 @@ describe("Error handling", () => {
                 }
 
                 response = await crawler.crawl(DEFAULT_BASE_URL);
+            });
+
+            test("updates the crawl status to running but not complete", () => {
+                expect(mockURLRepository.updateCrawlStatus).toBeCalledTimes(1);
+                expect(
+                    mockURLRepository.updateCrawlStatus
+                ).toHaveBeenCalledWith(
+                    EXPECTED_BASE_URL_HOSTNAME,
+                    CrawlStatus.STARTED
+                );
             });
 
             test("returns failure", () => {
@@ -376,6 +433,16 @@ describe("Error handling", () => {
                 );
             });
 
+            test("updates the crawl status to running but not complete", () => {
+                expect(mockURLRepository.updateCrawlStatus).toBeCalledTimes(1);
+                expect(
+                    mockURLRepository.updateCrawlStatus
+                ).toHaveBeenCalledWith(
+                    EXPECTED_BASE_URL_HOSTNAME,
+                    CrawlStatus.STARTED
+                );
+            });
+
             test("returns failure", () => {
                 expect(response.success).toBe(false);
             });
@@ -435,6 +502,16 @@ describe("Error handling", () => {
                 }
 
                 response = await crawler.crawl(DEFAULT_BASE_URL);
+            });
+
+            test("updates the crawl status to running but not complete", () => {
+                expect(mockURLRepository.updateCrawlStatus).toBeCalledTimes(1);
+                expect(
+                    mockURLRepository.updateCrawlStatus
+                ).toHaveBeenCalledWith(
+                    EXPECTED_BASE_URL_HOSTNAME,
+                    CrawlStatus.STARTED
+                );
             });
 
             test("returns failure", () => {

--- a/services/crawl/functions/recent-crawl/adapters/RecentCrawlEventAdapter.ts
+++ b/services/crawl/functions/recent-crawl/adapters/RecentCrawlEventAdapter.ts
@@ -39,6 +39,7 @@ class RecentCrawlEventAdapter implements RecentCrawlAdapter {
             return {
                 baseURL: url.hostname,
                 recentlyCrawled: response.recentlyCrawled,
+                status: response.status,
                 crawlTime: response.crawlTime,
             };
         }

--- a/services/crawl/functions/recent-crawl/adapters/__tests__/RecentCrawlEventAdapter.test.ts
+++ b/services/crawl/functions/recent-crawl/adapters/__tests__/RecentCrawlEventAdapter.test.ts
@@ -2,10 +2,7 @@ import { mock } from "jest-mock-extended";
 import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
 
 import { RecentCrawlEventAdapter } from "../RecentCrawlEventAdapter";
-import {
-    RecentCrawlAdapterResponse,
-    RecentCrawlEvent,
-} from "../../ports/RecentCrawlAdapter";
+import { RecentCrawlEvent } from "../../ports/RecentCrawlAdapter";
 import {
     RecentCrawlPort,
     RecentCrawlResponse,
@@ -29,8 +26,6 @@ test.each([
     ["invalid url (numeric)", "1"],
     ["invalid url", `test ${VALID_URL.toString()}`],
 ])("throws exception given %s", async (message: string, eventURL: string) => {
-    jest.resetAllMocks();
-
     const event = createEvent(eventURL);
 
     expect.assertions(1);
@@ -83,33 +78,39 @@ describe.each([
             crawlTime: new Date(),
         };
 
-        let response: RecentCrawlAdapterResponse;
-
-        beforeAll(async () => {
-            jest.resetAllMocks();
+        beforeEach(() => {
+            mockPort.hasCrawledRecently.mockReset();
             mockPort.hasCrawledRecently.mockResolvedValue(successResponse);
-
-            response = await adapter.hasCrawledRecently(event);
         });
 
-        test("calls domain with provided URL", () => {
+        test("calls domain with provided URL", async () => {
+            await adapter.hasCrawledRecently(event);
+
             expect(mockPort.hasCrawledRecently).toHaveBeenCalledTimes(1);
             expect(mockPort.hasCrawledRecently).toHaveBeenCalledWith(VALID_URL);
         });
 
-        test("returns provided URL's hostname in response", () => {
+        test("returns provided URL's hostname in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.baseURL).toEqual(expectedURLOutput);
         });
 
-        test("returns whether recently crawled in response", () => {
+        test("returns whether recently crawled in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.recentlyCrawled).toEqual(recentlyCrawled);
         });
 
-        test("returns crawl status in response", () => {
+        test("returns crawl status in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.status).toEqual(CrawlStatus.COMPLETE);
         });
 
-        test("returns crawl date time in response", () => {
+        test("returns crawl date time in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.crawlTime).toEqual(successResponse.crawlTime);
         });
     }
@@ -123,33 +124,39 @@ describe.each([
     (message: string, inputURL: URL | string, expectedURLOutput: string) => {
         const event = createEvent(inputURL);
 
-        let response: RecentCrawlAdapterResponse;
-
-        beforeAll(async () => {
-            jest.resetAllMocks();
+        beforeEach(async () => {
+            mockPort.hasCrawledRecently.mockReset();
             mockPort.hasCrawledRecently.mockResolvedValue(undefined);
-
-            response = await adapter.hasCrawledRecently(event);
         });
 
-        test("calls domain with valid URL", () => {
+        test("calls domain with valid URL", async () => {
+            await adapter.hasCrawledRecently(event);
+
             expect(mockPort.hasCrawledRecently).toHaveBeenCalledTimes(1);
             expect(mockPort.hasCrawledRecently).toHaveBeenCalledWith(VALID_URL);
         });
 
-        test("returns provided URL's hostname in response", () => {
+        test("returns provided URL's hostname in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.baseURL).toEqual(expectedURLOutput);
         });
 
-        test("returns not recently crawled in response", () => {
+        test("returns not recently crawled in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.recentlyCrawled).toEqual(false);
         });
 
-        test("returns no status in response", () => {
+        test("returns no status in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.status).toBeUndefined();
         });
 
-        test("returns no crawl datetime in response", () => {
+        test("returns no crawl datetime in response", async () => {
+            const response = await adapter.hasCrawledRecently(event);
+
             expect(response.crawlTime).toBeUndefined();
         });
     }

--- a/services/crawl/functions/recent-crawl/adapters/__tests__/RecentCrawlEventAdapter.test.ts
+++ b/services/crawl/functions/recent-crawl/adapters/__tests__/RecentCrawlEventAdapter.test.ts
@@ -1,4 +1,5 @@
 import { mock } from "jest-mock-extended";
+import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
 
 import { RecentCrawlEventAdapter } from "../RecentCrawlEventAdapter";
 import {
@@ -78,6 +79,7 @@ describe.each([
         const event = createEvent(inputURL);
         const successResponse: RecentCrawlResponse = {
             recentlyCrawled,
+            status: CrawlStatus.COMPLETE,
             crawlTime: new Date(),
         };
 
@@ -101,6 +103,10 @@ describe.each([
 
         test("returns whether recently crawled in response", () => {
             expect(response.recentlyCrawled).toEqual(recentlyCrawled);
+        });
+
+        test("returns crawl status in response", () => {
+            expect(response.status).toEqual(CrawlStatus.COMPLETE);
         });
 
         test("returns crawl date time in response", () => {
@@ -137,6 +143,10 @@ describe.each([
 
         test("returns not recently crawled in response", () => {
             expect(response.recentlyCrawled).toEqual(false);
+        });
+
+        test("returns no status in response", () => {
+            expect(response.status).toBeUndefined();
         });
 
         test("returns no crawl datetime in response", () => {

--- a/services/crawl/functions/recent-crawl/domain/RecentCrawlDomain.ts
+++ b/services/crawl/functions/recent-crawl/domain/RecentCrawlDomain.ts
@@ -12,15 +12,16 @@ class RecentCrawlDomain implements RecentCrawlPort {
     async hasCrawledRecently(
         baseURL: URL
     ): Promise<RecentCrawlResponse | undefined> {
-        const pathnameItem = await this.repository.getPathname(
-            baseURL.hostname,
-            baseURL.pathname
+        const crawlStatusRecord = await this.repository.getCrawlStatus(
+            baseURL.hostname
         );
 
-        if (pathnameItem) {
+        if (crawlStatusRecord) {
             return {
-                recentlyCrawled: this.isDateAfterMax(pathnameItem.createdAt),
-                crawlTime: pathnameItem.createdAt,
+                recentlyCrawled: this.isDateAfterMax(
+                    crawlStatusRecord.createdAt
+                ),
+                crawlTime: crawlStatusRecord.createdAt,
             };
         }
 

--- a/services/crawl/functions/recent-crawl/domain/RecentCrawlDomain.ts
+++ b/services/crawl/functions/recent-crawl/domain/RecentCrawlDomain.ts
@@ -21,6 +21,7 @@ class RecentCrawlDomain implements RecentCrawlPort {
                 recentlyCrawled: this.isDateAfterMax(
                     crawlStatusRecord.createdAt
                 ),
+                status: crawlStatusRecord.status,
                 crawlTime: crawlStatusRecord.createdAt,
             };
         }

--- a/services/crawl/functions/recent-crawl/domain/__tests__/RecentCrawlDomain.test.ts
+++ b/services/crawl/functions/recent-crawl/domain/__tests__/RecentCrawlDomain.test.ts
@@ -36,9 +36,9 @@ beforeEach(() => {
 
 describe.each([[CrawlStatus.STARTED], [CrawlStatus.COMPLETE]])(
     "given a crawl status of %s that was created before max age",
-    (crawlStatus: CrawlStatus) => {
+    (expectedStatus: CrawlStatus) => {
         const crawlStatusRecord = createCrawlStatusRecord(
-            crawlStatus,
+            expectedStatus,
             createDate(MAX_AGE_HOURS * -1 - 1)
         );
 
@@ -61,6 +61,12 @@ describe.each([[CrawlStatus.STARTED], [CrawlStatus.COMPLETE]])(
             expect(response?.recentlyCrawled).toEqual(false);
         });
 
+        test("returns the status of the crawl", async () => {
+            const response = await domain.hasCrawledRecently(VALID_URL);
+
+            expect(response?.status).toEqual(expectedStatus);
+        });
+
         test("returns time of the crawl status update", async () => {
             const response = await domain.hasCrawledRecently(VALID_URL);
 
@@ -71,9 +77,9 @@ describe.each([[CrawlStatus.STARTED], [CrawlStatus.COMPLETE]])(
 
 describe.each([[CrawlStatus.STARTED], [CrawlStatus.COMPLETE]])(
     "given a crawl status of %s that was created after max age",
-    (crawlStatus: CrawlStatus) => {
+    (expectedStatus: CrawlStatus) => {
         const crawlStatusRecord = createCrawlStatusRecord(
-            crawlStatus,
+            expectedStatus,
             createDate(MAX_AGE_HOURS)
         );
 
@@ -94,6 +100,12 @@ describe.each([[CrawlStatus.STARTED], [CrawlStatus.COMPLETE]])(
             const response = await domain.hasCrawledRecently(VALID_URL);
 
             expect(response?.recentlyCrawled).toEqual(true);
+        });
+
+        test("returns the status of the crawl", async () => {
+            const response = await domain.hasCrawledRecently(VALID_URL);
+
+            expect(response?.status).toEqual(expectedStatus);
         });
 
         test("returns time of the crawl status update", async () => {

--- a/services/crawl/functions/recent-crawl/ports/RecentCrawlAdapter.ts
+++ b/services/crawl/functions/recent-crawl/ports/RecentCrawlAdapter.ts
@@ -1,3 +1,5 @@
+import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
+
 type RecentCrawlEvent = {
     url?: string;
 };
@@ -5,6 +7,7 @@ type RecentCrawlEvent = {
 type RecentCrawlAdapterResponse = {
     baseURL: string;
     recentlyCrawled: boolean;
+    status?: CrawlStatus;
     crawlTime?: Date;
 };
 

--- a/services/crawl/functions/recent-crawl/ports/RecentCrawlPort.ts
+++ b/services/crawl/functions/recent-crawl/ports/RecentCrawlPort.ts
@@ -1,5 +1,8 @@
+import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
+
 type RecentCrawlResponse = {
     recentlyCrawled: boolean;
+    status: CrawlStatus;
     crawlTime: Date;
 };
 

--- a/services/crawl/libs/urls-repository-library/adapters/URLsTableRepository.ts
+++ b/services/crawl/libs/urls-repository-library/adapters/URLsTableRepository.ts
@@ -3,7 +3,7 @@ import dynamoose from "dynamoose";
 import { URLsTableKeyFields } from "../enums/URLsTableFields";
 import URLsTableConstants from "../enums/URLsTableConstants";
 import CrawlStatus from "../enums/CrawlStatus";
-import { Pathname, Repository } from "../ports/Repository";
+import { CrawlStatusRecord, Pathname, Repository } from "../ports/Repository";
 import URLsTablePathSchema from "../schemas/URLsTablePathSchema";
 import URLsTablePathItem from "../schemas/URLsTablePathItem";
 import URLsTableStatusItem from "../schemas/URLsTableStatusItem";
@@ -35,7 +35,9 @@ class URLsTableRepository implements Repository {
         });
     }
 
-    async getCrawlStatus(baseURL: string): Promise<CrawlStatus | undefined> {
+    async getCrawlStatus(
+        baseURL: string
+    ): Promise<CrawlStatusRecord | undefined> {
         const documents = await this.statusModel
             .query(URLsTableKeyFields.HashKey)
             .eq(this.createURLPartitionKey(baseURL))
@@ -47,7 +49,11 @@ class URLsTableRepository implements Repository {
             return undefined;
         }
 
-        return documents[0].status;
+        return {
+            status: documents[0].status,
+            createdAt: documents[0].createdAt,
+            updatedAt: documents[0].updatedAt,
+        };
     }
 
     async updateCrawlStatus(

--- a/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
+++ b/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
@@ -324,7 +324,7 @@ describe("Crawl Status operations", () => {
 
         const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
 
-        expect(actual).toEqual(CrawlStatus.COMPLETE);
+        expect(actual?.status).toEqual(CrawlStatus.COMPLETE);
     });
 
     test.each(Object.values(CrawlStatus))(
@@ -334,7 +334,52 @@ describe("Crawl Status operations", () => {
 
             const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
 
-            expect(actual).toEqual(expectedStatus);
+            expect(actual?.status).toEqual(expectedStatus);
         }
     );
+
+    test("updates the create timestamp for the crawl status if provided a new value", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
+        const before = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        await repository.updateCrawlStatus(
+            VALID_HOSTNAME,
+            CrawlStatus.COMPLETE
+        );
+        const after = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        expect(after?.createdAt).toEqual(expect.any(Date));
+        expect(after?.createdAt).not.toEqual(before?.createdAt);
+    });
+
+    test("updates the update timestamp for the crawl status if provided a new value", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
+        const before = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        await repository.updateCrawlStatus(
+            VALID_HOSTNAME,
+            CrawlStatus.COMPLETE
+        );
+        const after = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        expect(after?.createdAt).toEqual(expect.any(Date));
+        expect(after?.createdAt).not.toEqual(before?.createdAt);
+    });
+
+    test("returns created time if crawl status is stored for a base URL", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
+
+        const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        expect(actual?.createdAt).toEqual(expect.any(Date));
+    });
+
+    test("returns updated time equivalent to created time if crawl status is newly stored", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
+
+        const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        expect(actual?.updatedAt).toEqual(expect.any(Date));
+        expect(actual?.updatedAt).toEqual(actual?.createdAt);
+    });
 });

--- a/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
+++ b/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
@@ -270,27 +270,21 @@ describe("Crawl Status operations", () => {
         expect(response).toEqual(true);
     });
 
-    describe("deletes status if crawl status is set", () => {
-        beforeEach(async () => {
-            await repository.updateCrawlStatus(
-                VALID_HOSTNAME,
-                CrawlStatus.STARTED
-            );
-        });
+    test("returns success when deleting an existing crawl status", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
 
-        test("crawl status is successfully deleted", async () => {
-            await repository.deleteCrawlStatus(VALID_HOSTNAME);
+        const response = await repository.deleteCrawlStatus(VALID_HOSTNAME);
 
-            const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
+        expect(response).toBe(true);
+    });
 
-            expect(actual).toBeUndefined();
-        });
+    test("succesfully deletes an existing crawl status", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
+        await repository.deleteCrawlStatus(VALID_HOSTNAME);
 
-        test("returns success", async () => {
-            const response = await repository.deleteCrawlStatus(VALID_HOSTNAME);
+        const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
 
-            expect(response).toEqual(true);
-        });
+        expect(actual).toBeUndefined();
     });
 
     test("returns undefined if no crawl status is stored for a base URL", async () => {
@@ -310,32 +304,27 @@ describe("Crawl Status operations", () => {
         expect(response).toEqual(true);
     });
 
-    describe("overwrites status if crawl status is already set", () => {
-        beforeAll(async () => {
-            await repository.updateCrawlStatus(
-                VALID_HOSTNAME,
-                CrawlStatus.STARTED
-            );
-        });
+    test("returns success when overwriting an existing crawl status", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
 
-        test("updates status of crawl successfully", async () => {
-            await repository.updateCrawlStatus(
-                VALID_HOSTNAME,
-                CrawlStatus.COMPLETE
-            );
+        const response = await repository.updateCrawlStatus(
+            VALID_HOSTNAME,
+            CrawlStatus.COMPLETE
+        );
 
-            const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
+        expect(response).toEqual(true);
+    });
 
-            expect(actual).toEqual(CrawlStatus.COMPLETE);
-        });
+    test("overwrites an existing crawl status with a new value", async () => {
+        await repository.updateCrawlStatus(VALID_HOSTNAME, CrawlStatus.STARTED);
+        await repository.updateCrawlStatus(
+            VALID_HOSTNAME,
+            CrawlStatus.COMPLETE
+        );
 
-        test("returns success", async () => {
-            const response = await repository.updateCrawlStatus(
-                VALID_HOSTNAME,
-                CrawlStatus.COMPLETE
-            );
-            expect(response).toEqual(true);
-        });
+        const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
+
+        expect(actual).toEqual(CrawlStatus.COMPLETE);
     });
 
     test.each(Object.values(CrawlStatus))(

--- a/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
+++ b/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
@@ -276,7 +276,7 @@ describe("Crawl Status operations", () => {
         beforeAll(async () => {
             await repository.updateCrawlStatus(
                 VALID_HOSTNAME,
-                CrawlStatus.RUNNING
+                CrawlStatus.STARTED
             );
 
             response = await repository.deleteCrawlStatus(VALID_HOSTNAME);
@@ -304,7 +304,7 @@ describe("Crawl Status operations", () => {
     test("returns success if crawl status update succeeds", async () => {
         const response = await repository.updateCrawlStatus(
             VALID_HOSTNAME,
-            CrawlStatus.SUCCESS
+            CrawlStatus.COMPLETE
         );
 
         expect(response).toEqual(true);
@@ -316,19 +316,19 @@ describe("Crawl Status operations", () => {
         beforeAll(async () => {
             await repository.updateCrawlStatus(
                 VALID_HOSTNAME,
-                CrawlStatus.RUNNING
+                CrawlStatus.STARTED
             );
 
             response = await repository.updateCrawlStatus(
                 VALID_HOSTNAME,
-                CrawlStatus.SUCCESS
+                CrawlStatus.COMPLETE
             );
         });
 
         test("updates status of crawl successfully", async () => {
             const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
 
-            expect(actual).toEqual(CrawlStatus.SUCCESS);
+            expect(actual).toEqual(CrawlStatus.COMPLETE);
         });
 
         test("returns success", () => {

--- a/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
+++ b/services/crawl/libs/urls-repository-library/adapters/__tests__/URLsTableRepository.test.ts
@@ -271,24 +271,24 @@ describe("Crawl Status operations", () => {
     });
 
     describe("deletes status if crawl status is set", () => {
-        let response: boolean;
-
-        beforeAll(async () => {
+        beforeEach(async () => {
             await repository.updateCrawlStatus(
                 VALID_HOSTNAME,
                 CrawlStatus.STARTED
             );
-
-            response = await repository.deleteCrawlStatus(VALID_HOSTNAME);
         });
 
         test("crawl status is successfully deleted", async () => {
+            await repository.deleteCrawlStatus(VALID_HOSTNAME);
+
             const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
 
             expect(actual).toBeUndefined();
         });
 
-        test("returns success", () => {
+        test("returns success", async () => {
+            const response = await repository.deleteCrawlStatus(VALID_HOSTNAME);
+
             expect(response).toEqual(true);
         });
     });
@@ -311,27 +311,29 @@ describe("Crawl Status operations", () => {
     });
 
     describe("overwrites status if crawl status is already set", () => {
-        let response: boolean;
-
         beforeAll(async () => {
             await repository.updateCrawlStatus(
                 VALID_HOSTNAME,
                 CrawlStatus.STARTED
             );
-
-            response = await repository.updateCrawlStatus(
-                VALID_HOSTNAME,
-                CrawlStatus.COMPLETE
-            );
         });
 
         test("updates status of crawl successfully", async () => {
+            await repository.updateCrawlStatus(
+                VALID_HOSTNAME,
+                CrawlStatus.COMPLETE
+            );
+
             const actual = await repository.getCrawlStatus(VALID_HOSTNAME);
 
             expect(actual).toEqual(CrawlStatus.COMPLETE);
         });
 
-        test("returns success", () => {
+        test("returns success", async () => {
+            const response = await repository.updateCrawlStatus(
+                VALID_HOSTNAME,
+                CrawlStatus.COMPLETE
+            );
             expect(response).toEqual(true);
         });
     });

--- a/services/crawl/libs/urls-repository-library/enums/CrawlStatus.ts
+++ b/services/crawl/libs/urls-repository-library/enums/CrawlStatus.ts
@@ -1,6 +1,6 @@
 enum CrawlStatus {
-    SUCCESS = "SUCCESS",
-    RUNNING = "RUNNING",
+    COMPLETE = "COMPLETE",
+    STARTED = "STARTED",
 }
 
 export default CrawlStatus;

--- a/services/crawl/libs/urls-repository-library/index.ts
+++ b/services/crawl/libs/urls-repository-library/index.ts
@@ -1,5 +1,11 @@
 import CrawlStatus from "./enums/CrawlStatus";
-import { Pathname, Repository } from "./ports/Repository";
+import { CrawlStatusRecord, Pathname, Repository } from "./ports/Repository";
 import URLsTableRepository from "./adapters/URLsTableRepository";
 
-export { CrawlStatus, Pathname, Repository, URLsTableRepository };
+export {
+    CrawlStatus,
+    CrawlStatusRecord,
+    Pathname,
+    Repository,
+    URLsTableRepository,
+};

--- a/services/crawl/libs/urls-repository-library/index.ts
+++ b/services/crawl/libs/urls-repository-library/index.ts
@@ -1,4 +1,5 @@
+import CrawlStatus from "./enums/CrawlStatus";
 import { Pathname, Repository } from "./ports/Repository";
 import URLsTableRepository from "./adapters/URLsTableRepository";
 
-export { Pathname, Repository, URLsTableRepository };
+export { CrawlStatus, Pathname, Repository, URLsTableRepository };

--- a/services/crawl/libs/urls-repository-library/ports/Repository.ts
+++ b/services/crawl/libs/urls-repository-library/ports/Repository.ts
@@ -6,6 +6,12 @@ type Pathname = {
     updatedAt: Date;
 };
 
+type CrawlStatusRecord = {
+    status: CrawlStatus;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
 interface Repository {
     deletePathnames(baseURL: string): Promise<boolean>;
     getPathnames(baseURL: string): Promise<Pathname[]>;
@@ -14,9 +20,9 @@ interface Repository {
         pathname: string
     ): Promise<Pathname | undefined>;
     storePathname(baseURL: string, pathname: string): Promise<boolean>;
-    getCrawlStatus(baseURL: string): Promise<CrawlStatus | undefined>;
+    getCrawlStatus(baseURL: string): Promise<CrawlStatusRecord | undefined>;
     updateCrawlStatus(baseURL: string, status: CrawlStatus): Promise<boolean>;
     deleteCrawlStatus(baseURL: string): Promise<boolean>;
 }
 
-export { Pathname, Repository };
+export { CrawlStatusRecord, Pathname, Repository };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15846,9 +15846,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-            "integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -29363,9 +29363,9 @@
             }
         },
         "terser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.0.tgz",
-            "integrity": "sha512-JC6qfIEkPBd9j1SMO3Pfn+A6w2kQV54tv+ABQLgZr7dA3k/DL/OBoYSWxzVpZev3J+bUHXfr55L8Mox7AaNo6g==",
+            "version": "5.14.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+            "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",


### PR DESCRIPTION
Resolves #172 

# What

Updated crawl urls lambda to store crawl status upon starting and completing a crawl of a given site
Updated recent crawl lambda to:
- Use crawl status DynamoDB record to dictate whether a crawl was recently performed
- Return the crawl status if set

Updated URLs Table Repository library to return crawl status record timestamps from getCrawlStatus method

# Why

To fix an issue whereby subscribers could receive a COMPLETE status for a given crawl before it finished
- Was set to send complete regardless of whether the crawl was still ongoing
- Now sends the current status

