### PR TITLE
Feature/170 publish failure updates

### DIFF
--- a/docs/c4-diagrams/buzzword-c4-component-crawl-microservice.puml
+++ b/docs/c4-diagrams/buzzword-c4-component-crawl-microservice.puml
@@ -16,6 +16,7 @@ Container_Boundary(crawl_microservice_boundary, "Crawl Microservice") {
     Component(get_content_lambda, "Get Content Lambda", "Lambda and TypeScript", "Retrieves content of recently crawled pages")
     Component(get_urls_lambda, "Get URLs Lambda", "Lambda and TypeScript", "Gets all URLs crawled from a given URL")
     Component(publish_urls_lambda, "Publish URLs Lambda", "Lambda and JavaScript", "Publishes newly crawled URLs as event to event bus")
+    Component(update_status_lambda, "Update Status Lambda", "Lambda and TypeScript", "Updates the crawl status in DynamoDB and publishes crawl status update messages to subscribed clients")
     Component(event_bus, "Event Bus", "Event Bridge", "Event bus service that provides subscribers relevant events")
 }
 
@@ -34,19 +35,23 @@ Rel_R(api_gateway, get_content_lambda, "Routes requests to get crawled page cont
 Rel(step_function, recent_crawl_lambda, "Uses")
 Rel(step_function, crawl_urls_lambda, "Initiates crawl if not recently crawled")
 Rel(step_function, event_bus, "Sends crawl complete events containing all crawled URLs and status updates to")
+Rel(step_function, update_status_lambda, "Updates crawl status to failure if an error occurs during crawl")
 
 Rel(recent_crawl_lambda, url_db, "Reads from", "Dynamoose")
 
 Rel(crawl_urls_lambda, url_db, "Writes to", "Dynamoose")
-Rel_R(crawl_urls_lambda, content_db, "Writes to", "S3 Client")
-Rel_D(crawl_urls_lambda, websites, "Crawls content using", "HTTP")
+Rel(crawl_urls_lambda, content_db, "Writes to", "S3 Client")
+Rel(crawl_urls_lambda, websites, "Crawls content using", "HTTP")
 
 Rel(get_urls_lambda, url_db, "Reads from", "Dynamoose")
 
 Rel(get_content_lambda, content_db, "Reads from", "S3 Client")
 
-Rel_U(publish_urls_lambda, url_db, "Listens to updates from", "DynamoDB Stream")
-Rel_R(publish_urls_lambda, event_bus, "Sends new URL event containing new URL to", "Event Bridge Client")
+Rel_R(publish_urls_lambda, url_db, "Listens to updates from", "DynamoDB Stream")
+Rel_L(publish_urls_lambda, event_bus, "Sends new URL event containing new URL to", "Event Bridge Client")
+
+Rel(update_status_lambda, url_db, "Writes to", "Dynamoose")
+Rel(update_status_lambda, event_bus, "Sends crawl status updates to subscribing clients via")
 
 Rel(keyphrase_microservice, event_bus, "Subscribes to crawl complete events from")
 Rel(graphql_api, event_bus, "Subscribes to crawl status updates from")

--- a/docs/c4-diagrams/buzzword-c4-component-crawl-microservice.puml
+++ b/docs/c4-diagrams/buzzword-c4-component-crawl-microservice.puml
@@ -51,7 +51,7 @@ Rel_R(publish_urls_lambda, url_db, "Listens to updates from", "DynamoDB Stream")
 Rel_L(publish_urls_lambda, event_bus, "Sends new URL event containing new URL to", "Event Bridge Client")
 
 Rel(update_status_lambda, url_db, "Writes to", "Dynamoose")
-Rel(update_status_lambda, event_bus, "Sends crawl status updates to subscribing clients via")
+Rel(update_status_lambda, event_bus, "Sends crawl status updates to")
 
 Rel(keyphrase_microservice, event_bus, "Subscribes to crawl complete events from")
 Rel(graphql_api, event_bus, "Subscribes to crawl status updates from")

--- a/services/crawl/crawl-template.yml
+++ b/services/crawl/crawl-template.yml
@@ -698,6 +698,14 @@ Resources:
                                 - dynamodb:PutItem
                             Resource: !GetAtt URLsTable.Arn
                             Effect: Allow
+                - PolicyName: PublishEventPolicy
+                  PolicyDocument:
+                      Version: "2012-10-17"
+                      Statement:
+                          - Action:
+                                - events:PutEvents
+                            Resource: !GetAtt CrawlServiceEventBus.Arn
+                            Effect: Allow
             ManagedPolicyArns:
                 - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
     UpdateStatus:
@@ -715,6 +723,7 @@ Resources:
             Environment:
                 Variables:
                     TABLE_NAME: !Ref URLsTable
+                    EVENT_BUS_NAME: !GetAtt CrawlServiceEventBus.Arn
 Outputs:
     EventBusARN:
         Description: The ARN for the Crawl Service's Event Bus

--- a/services/crawl/functions/update-status/__tests__/update-status.test.ts
+++ b/services/crawl/functions/update-status/__tests__/update-status.test.ts
@@ -1,4 +1,10 @@
 jest.mock("buzzword-aws-crawl-urls-repository-library");
+jest.mock("@aws-sdk/client-eventbridge");
+
+beforeEach(() => {
+    process.env.TABLE_NAME = "test_table_name";
+    process.env.EVENT_BUS_NAME = "test_event_bus_name";
+});
 
 test("throws error if table name is undefined", async () => {
     delete process.env.TABLE_NAME;
@@ -7,4 +13,13 @@ test("throws error if table name is undefined", async () => {
     await expect(async () => {
         await import("../update-status");
     }).rejects.toThrow(new Error("URLs table name has not been set."));
+});
+
+test("throws error if event bus is undefined", async () => {
+    delete process.env.EVENT_BUS_NAME;
+
+    expect.assertions(1);
+    await expect(async () => {
+        await import("../update-status");
+    }).rejects.toThrow(new Error("Crawl event bus name has not been set."));
 });

--- a/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
+++ b/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
@@ -39,8 +39,15 @@ class EventBridgeClient implements EventClient {
 
         try {
             await this.client.send(command);
+            console.log(
+                `Successfully sent status update: ${status} for URL: ${url}`
+            );
+
             return true;
-        } catch {
+        } catch (ex) {
+            console.error(
+                `An error occurred sending status update for URL: ${url}. Error: ${ex}`
+            );
             return false;
         }
     }

--- a/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
+++ b/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
@@ -1,0 +1,45 @@
+import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
+import {
+    EventBridgeClient as EBClient,
+    PutEventsCommand,
+    PutEventsRequestEntry,
+} from "@aws-sdk/client-eventbridge";
+
+import EventClient from "../ports/EventClient";
+
+const CRAWL_STATUS_UPDATE_DETAIL = "Crawl Complete via Crawl Service";
+const CRAWL_SERVICE_SOURCE = "crawl.aws.buzzword";
+
+type StatusUpdateEntryDetail = {
+    baseURL: string;
+    status: CrawlStatus;
+};
+
+class EventBridgeClient implements EventClient {
+    private client: EBClient;
+
+    constructor(private eventBusName: string) {
+        this.client = new EBClient({});
+    }
+
+    async sentStatusUpdate(url: string, status: CrawlStatus): Promise<boolean> {
+        const detail: StatusUpdateEntryDetail = {
+            baseURL: url,
+            status,
+        };
+
+        const entry: PutEventsRequestEntry = {
+            EventBusName: this.eventBusName,
+            DetailType: CRAWL_STATUS_UPDATE_DETAIL,
+            Source: CRAWL_SERVICE_SOURCE,
+            Detail: JSON.stringify(detail),
+        };
+
+        const command = new PutEventsCommand({ Entries: [entry] });
+        this.client.send(command);
+
+        return true;
+    }
+}
+
+export default EventBridgeClient;

--- a/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
+++ b/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
@@ -7,7 +7,7 @@ import {
 
 import EventClient from "../ports/EventClient";
 
-const CRAWL_STATUS_UPDATE_DETAIL = "Crawl Complete via Crawl Service";
+const CRAWL_STATUS_UPDATE_DETAIL = "Crawl Status Update";
 const CRAWL_SERVICE_SOURCE = "crawl.aws.buzzword";
 
 type StatusUpdateEntryDetail = {

--- a/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
+++ b/services/crawl/functions/update-status/adapters/EventBridgeClient.ts
@@ -36,9 +36,13 @@ class EventBridgeClient implements EventClient {
         };
 
         const command = new PutEventsCommand({ Entries: [entry] });
-        this.client.send(command);
 
-        return true;
+        try {
+            await this.client.send(command);
+            return true;
+        } catch {
+            return false;
+        }
     }
 }
 

--- a/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
+++ b/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
@@ -106,3 +106,14 @@ test("returns success given event is succesfully sent", async () => {
 
     expect(response).toEqual(true);
 });
+
+test("returns failure if an unknown error occurs during sending of event", async () => {
+    mockEventBridgeClient.on(PutEventsCommand).rejects(new Error());
+
+    const response = await client.sentStatusUpdate(
+        VALID_HOSTNAME,
+        VALID_STATUS
+    );
+
+    expect(response).toEqual(false);
+});

--- a/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
+++ b/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
@@ -49,7 +49,7 @@ test("sends the event bus name in the event entry", async () => {
 });
 
 test("sends the crawl status detail type in the event entry", async () => {
-    const expectedDetailType = "Crawl Complete via Crawl Service";
+    const expectedDetailType = "Crawl Status Update";
 
     await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
     const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);

--- a/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
+++ b/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
@@ -1,0 +1,108 @@
+import { mockClient } from "aws-sdk-client-mock";
+import {
+    EventBridgeClient as EBClient,
+    PutEventsCommand,
+} from "@aws-sdk/client-eventbridge";
+import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
+
+import EventBridgeClient from "../EventBridgeClient";
+
+const VALID_HOSTNAME = "www.example.com";
+const VALID_STATUS = CrawlStatus.COMPLETE;
+
+const EXPECTED_EVENT_BUS_NAME = "test_event_bus";
+
+const mockEventBridgeClient = mockClient(EBClient);
+
+const client = new EventBridgeClient(EXPECTED_EVENT_BUS_NAME);
+
+beforeEach(() => {
+    mockEventBridgeClient.reset();
+});
+
+test("sends a single event and entry for the provided status", async () => {
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toHaveLength(1);
+});
+
+test("sends a single entry in the event", async () => {
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const entries = calls[0].args[0].input.Entries;
+
+    expect(entries).toHaveLength(1);
+});
+
+test("sends the event bus name in the event entry", async () => {
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const entries = calls[0].args[0].input.Entries;
+
+    expect(entries?.[0].EventBusName).toEqual(EXPECTED_EVENT_BUS_NAME);
+});
+
+test("sends the crawl status detail type in the event entry", async () => {
+    const expectedDetailType = "Crawl Complete via Crawl Service";
+
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const entries = calls[0].args[0].input.Entries;
+
+    expect(entries?.[0].DetailType).toEqual(expectedDetailType);
+});
+
+test("sends the buzzword crawl source in the event entry", async () => {
+    const expectedSource = "crawl.aws.buzzword";
+
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const entries = calls[0].args[0].input.Entries;
+
+    expect(entries?.[0].Source).toEqual(expectedSource);
+});
+
+test("sends a JSON message in the entry detail", async () => {
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const entries = calls[0].args[0].input.Entries;
+
+    expect(() =>
+        JSON.parse(entries?.[0].Detail || "invalid")
+    ).not.toThrowError();
+});
+
+test("sends the provided URL in the entry detail", async () => {
+    const expectedURLKey = "baseURL";
+
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const detail = JSON.parse(
+        calls[0].args[0].input.Entries?.[0].Detail || "unexpected"
+    );
+
+    expect(detail[expectedURLKey]).toEqual(VALID_HOSTNAME);
+});
+
+test("sends the provided status in the entry detail", async () => {
+    const expectedStatusKey = "status";
+
+    await client.sentStatusUpdate(VALID_HOSTNAME, VALID_STATUS);
+    const calls = mockEventBridgeClient.commandCalls(PutEventsCommand);
+    const detail = JSON.parse(
+        calls[0].args[0].input.Entries?.[0].Detail || "unexpected"
+    );
+
+    expect(detail[expectedStatusKey]).toEqual(VALID_STATUS);
+});
+
+test("returns success given event is succesfully sent", async () => {
+    const response = await client.sentStatusUpdate(
+        VALID_HOSTNAME,
+        VALID_STATUS
+    );
+
+    expect(response).toEqual(true);
+});

--- a/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
+++ b/services/crawl/functions/update-status/adapters/__tests__/EventBridgeClient.test.ts
@@ -16,6 +16,10 @@ const mockEventBridgeClient = mockClient(EBClient);
 
 const client = new EventBridgeClient(EXPECTED_EVENT_BUS_NAME);
 
+beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
 beforeEach(() => {
     mockEventBridgeClient.reset();
 });
@@ -108,6 +112,7 @@ test("returns success given event is succesfully sent", async () => {
 });
 
 test("returns failure if an unknown error occurs during sending of event", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
     mockEventBridgeClient.on(PutEventsCommand).rejects(new Error());
 
     const response = await client.sentStatusUpdate(

--- a/services/crawl/functions/update-status/domain/UpdateStatusDomain.ts
+++ b/services/crawl/functions/update-status/domain/UpdateStatusDomain.ts
@@ -4,19 +4,32 @@ import {
 } from "buzzword-aws-crawl-urls-repository-library";
 
 import UpdateStatusPort from "../ports/UpdateStatusPort";
+import EventClient from "../ports/EventClient";
 
 class UpdateStatusDomain implements UpdateStatusPort {
-    constructor(private repository: Repository) {}
+    constructor(
+        private repository: Repository,
+        private eventClient: EventClient
+    ) {}
 
     async updateCrawlStatus(
         baseURL: URL,
         newStatus: CrawlStatus
     ): Promise<boolean> {
         try {
-            return await this.repository.updateCrawlStatus(
+            const statusUpdated = await this.repository.updateCrawlStatus(
                 baseURL.hostname,
                 newStatus
             );
+
+            if (statusUpdated) {
+                return await this.eventClient.sentStatusUpdate(
+                    baseURL.hostname,
+                    newStatus
+                );
+            }
+
+            return false;
         } catch {
             return false;
         }

--- a/services/crawl/functions/update-status/domain/__tests__/UpdateStatusDomain.test.ts
+++ b/services/crawl/functions/update-status/domain/__tests__/UpdateStatusDomain.test.ts
@@ -5,19 +5,23 @@ import {
 } from "buzzword-aws-crawl-urls-repository-library";
 
 import UpdateStatusDomain from "../UpdateStatusDomain";
+import EventClient from "../../ports/EventClient";
 
 const mockRepository = mock<Repository>();
+const mockEventClient = mock<EventClient>();
 
-const domain = new UpdateStatusDomain(mockRepository);
+const domain = new UpdateStatusDomain(mockRepository, mockEventClient);
 
 const EXPECTED_URL = new URL("https://www.example.com/");
 
 beforeEach(() => {
     mockRepository.updateCrawlStatus.mockReset();
+    mockEventClient.sentStatusUpdate.mockReset();
 });
 
-test("returns success if the crawl status update was successful", async () => {
+test("returns success if the crawl status update and event publish were successful", async () => {
     mockRepository.updateCrawlStatus.mockResolvedValue(true);
+    mockEventClient.sentStatusUpdate.mockResolvedValue(true);
 
     const actual = await domain.updateCrawlStatus(
         EXPECTED_URL,
@@ -40,6 +44,35 @@ test.each(Object.values(CrawlStatus))(
     }
 );
 
+test("calls the event client to publish status update if crawl status update was successful", async () => {
+    const expectedStatus = CrawlStatus.COMPLETE;
+    mockRepository.updateCrawlStatus.mockResolvedValue(true);
+
+    await domain.updateCrawlStatus(EXPECTED_URL, expectedStatus);
+
+    expect(mockEventClient.sentStatusUpdate).toHaveBeenCalledTimes(1);
+    expect(mockEventClient.sentStatusUpdate).toHaveBeenCalledWith(
+        EXPECTED_URL.hostname,
+        expectedStatus
+    );
+});
+
+test("does not call the event client if an unhandled exception occurs while updating crawl status in repository", async () => {
+    mockRepository.updateCrawlStatus.mockRejectedValue(new Error());
+
+    await domain.updateCrawlStatus(EXPECTED_URL, CrawlStatus.COMPLETE);
+
+    expect(mockEventClient.sentStatusUpdate).not.toHaveBeenCalled();
+});
+
+test("does not call the event client if the crawl status update failed", async () => {
+    mockRepository.updateCrawlStatus.mockResolvedValue(false);
+
+    await domain.updateCrawlStatus(EXPECTED_URL, CrawlStatus.COMPLETE);
+
+    expect(mockEventClient.sentStatusUpdate).not.toHaveBeenCalled();
+});
+
 test("returns failure if an unhandled exception occurs while updating crawl status in repository", async () => {
     mockRepository.updateCrawlStatus.mockRejectedValue(new Error());
 
@@ -53,6 +86,30 @@ test("returns failure if an unhandled exception occurs while updating crawl stat
 
 test("returns failure if the repository fails to update the crawl status for the given URL", async () => {
     mockRepository.updateCrawlStatus.mockResolvedValue(false);
+
+    const actual = await domain.updateCrawlStatus(
+        EXPECTED_URL,
+        CrawlStatus.COMPLETE
+    );
+
+    expect(actual).toEqual(false);
+});
+
+test("returns failure if an unhandled exception occurs while sending status update event", async () => {
+    mockRepository.updateCrawlStatus.mockResolvedValue(true);
+    mockEventClient.sentStatusUpdate.mockRejectedValue(new Error());
+
+    const actual = await domain.updateCrawlStatus(
+        EXPECTED_URL,
+        CrawlStatus.COMPLETE
+    );
+
+    expect(actual).toEqual(false);
+});
+
+test("returns failure if the event client fails to send the status update", async () => {
+    mockRepository.updateCrawlStatus.mockResolvedValue(true);
+    mockEventClient.sentStatusUpdate.mockResolvedValue(false);
 
     const actual = await domain.updateCrawlStatus(
         EXPECTED_URL,

--- a/services/crawl/functions/update-status/package-lock.json
+++ b/services/crawl/functions/update-status/package-lock.json
@@ -6,7 +6,1578 @@
     "packages": {
         "": {
             "name": "buzzword-aws-update-status-lambda",
-            "version": "1.0.0"
+            "version": "1.0.0",
+            "dependencies": {
+                "@aws-sdk/client-eventbridge": "3.55.0"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dependencies": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+            "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-sdk/abort-controller": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
+            "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-eventbridge": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.55.0.tgz",
+            "integrity": "sha512-6VRYbVPDHr1+PWCHF0khtpTNS5t/cRQzBCr6oIN+iVt8D+HH5A1BKapfpctwq92mTS3B6JxWVsiTlPUU1BtI4w==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.55.0",
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/credential-provider-node": "3.55.0",
+                "@aws-sdk/fetch-http-handler": "3.55.0",
+                "@aws-sdk/hash-node": "3.55.0",
+                "@aws-sdk/invalid-dependency": "3.55.0",
+                "@aws-sdk/middleware-content-length": "3.55.0",
+                "@aws-sdk/middleware-host-header": "3.55.0",
+                "@aws-sdk/middleware-logger": "3.55.0",
+                "@aws-sdk/middleware-retry": "3.55.0",
+                "@aws-sdk/middleware-serde": "3.55.0",
+                "@aws-sdk/middleware-signing": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/middleware-user-agent": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/node-http-handler": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/smithy-client": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "@aws-sdk/util-base64-node": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.55.0",
+                "@aws-sdk/util-defaults-mode-node": "3.55.0",
+                "@aws-sdk/util-user-agent-browser": "3.55.0",
+                "@aws-sdk/util-user-agent-node": "3.55.0",
+                "@aws-sdk/util-utf8-browser": "3.55.0",
+                "@aws-sdk/util-utf8-node": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.55.0.tgz",
+            "integrity": "sha512-bIGy2xkWZ00Vn5ByLIQamHVbzSE6Pbcs67873otNWtpkygfMzvQRFZ8RB6J+C6BuAwT3xTLI0aNi40RxxwM4HQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/fetch-http-handler": "3.55.0",
+                "@aws-sdk/hash-node": "3.55.0",
+                "@aws-sdk/invalid-dependency": "3.55.0",
+                "@aws-sdk/middleware-content-length": "3.55.0",
+                "@aws-sdk/middleware-host-header": "3.55.0",
+                "@aws-sdk/middleware-logger": "3.55.0",
+                "@aws-sdk/middleware-retry": "3.55.0",
+                "@aws-sdk/middleware-serde": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/middleware-user-agent": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/node-http-handler": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/smithy-client": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "@aws-sdk/util-base64-node": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.55.0",
+                "@aws-sdk/util-defaults-mode-node": "3.55.0",
+                "@aws-sdk/util-user-agent-browser": "3.55.0",
+                "@aws-sdk/util-user-agent-node": "3.55.0",
+                "@aws-sdk/util-utf8-browser": "3.55.0",
+                "@aws-sdk/util-utf8-node": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.55.0.tgz",
+            "integrity": "sha512-/xmx0bxvhL9ffQ7A263MyTAfC6G0cyy/FwTmTWTt2xoKCNub7sGrPCJOjZB5fvmy9FpUvFUOJw1DnCghANKxzw==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/credential-provider-node": "3.55.0",
+                "@aws-sdk/fetch-http-handler": "3.55.0",
+                "@aws-sdk/hash-node": "3.55.0",
+                "@aws-sdk/invalid-dependency": "3.55.0",
+                "@aws-sdk/middleware-content-length": "3.55.0",
+                "@aws-sdk/middleware-host-header": "3.55.0",
+                "@aws-sdk/middleware-logger": "3.55.0",
+                "@aws-sdk/middleware-retry": "3.55.0",
+                "@aws-sdk/middleware-sdk-sts": "3.55.0",
+                "@aws-sdk/middleware-serde": "3.55.0",
+                "@aws-sdk/middleware-signing": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/middleware-user-agent": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/node-http-handler": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/smithy-client": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "@aws-sdk/util-base64-node": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.55.0",
+                "@aws-sdk/util-defaults-mode-node": "3.55.0",
+                "@aws-sdk/util-user-agent-browser": "3.55.0",
+                "@aws-sdk/util-user-agent-node": "3.55.0",
+                "@aws-sdk/util-utf8-browser": "3.55.0",
+                "@aws-sdk/util-utf8-node": "3.55.0",
+                "entities": "2.2.0",
+                "fast-xml-parser": "3.19.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.55.0.tgz",
+            "integrity": "sha512-dW+UcGu6f+RA1ZsiSpdWUrWwrhevXZeeBtr08X83TP7dK8S6HHv5upX+4es1xou6aMqqin+yHZUVmabvAe/gpg==",
+            "dependencies": {
+                "@aws-sdk/signature-v4": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-config-provider": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
+            "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.55.0.tgz",
+            "integrity": "sha512-aBOQomxYwNHQSHuOetrER1r13x3tJWNd9Eho2OcGLRioNS6/on2T5ptQI5/pJvAqOWe7LG65k1g3eTf1T8Nf1Q==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.55.0.tgz",
+            "integrity": "sha512-f4+8mqJ1xapF9SR90VC+Ho4zlnLPdCgAAm9f7Pauf1/beAk5bkmfLshLwQ5Jo4oEPbWLn1Sdk403kwnxpsnksg==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.55.0",
+                "@aws-sdk/credential-provider-imds": "3.55.0",
+                "@aws-sdk/credential-provider-sso": "3.55.0",
+                "@aws-sdk/credential-provider-web-identity": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.55.0.tgz",
+            "integrity": "sha512-cDAk2+29sZyluk3D2vomCJd0adJxjun9yVdyAiuoutxx9LZ1KQgsDEVHDbPQFpmeOBBagtMNpHNVtUunQ3yy1w==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.55.0",
+                "@aws-sdk/credential-provider-imds": "3.55.0",
+                "@aws-sdk/credential-provider-ini": "3.55.0",
+                "@aws-sdk/credential-provider-process": "3.55.0",
+                "@aws-sdk/credential-provider-sso": "3.55.0",
+                "@aws-sdk/credential-provider-web-identity": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.55.0.tgz",
+            "integrity": "sha512-09AGJ6bdonXpV/dyHzrQqcbo2oy3aDxjcq+/LGo4GuB0ZHD2TJqKpExU7ie0rg/5OdBnTX6c+9JyjeFt03uX7w==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.55.0.tgz",
+            "integrity": "sha512-hKWbZMDY5nZMsOKMVkeUrKCdHaemMhyAH4WfApq976DDJt6bm6U+jvkTspO8qQaIPD8xdRqyi5AMLvVcHjBbTg==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
+            "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.55.0.tgz",
+            "integrity": "sha512-/Sta3MLlszpRZ1pg+ClxfNqGvraX93F587eHrfQMaGXgQ2BqJLiAVRorBRGcmmmrHxfLOqspNqufF7ibrqziRQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/querystring-builder": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
+            "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-buffer-from": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
+            "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
+            "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.55.0.tgz",
+            "integrity": "sha512-IkFBwa1G5ERfKFh4Kdtcn/aNAGi3Hcp9IO1PVt69LZWaevxjXAi5NS2k65E9mZPEumzuLtcEeC+3qhPs4FUkqQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.55.0.tgz",
+            "integrity": "sha512-69mTWJfuPP4aC+h2/cb9B2CUNA9tiRPUBp67dmMrA2dHyy53kNYo8TGgfLKProoBidBz/AVXIfnh+izJj0F20w==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
+            "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.55.0.tgz",
+            "integrity": "sha512-Z0j4/zyvgp8Y7HYud1MCqheg9koVh7p1ekS8lm6GePZBWILXsFib8PK9eq7B16u2z7yyz2tHrzwQrHRRr0cQKQ==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/service-error-classification": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.55.0.tgz",
+            "integrity": "sha512-BrK3UXmD08rGbhY6cAHXsQxDfflOrPbKe4gxymlckd9sGIPC42O1KfJQ0CaxWPvG1Gd3R/QFfoPFClpTDhdh0Q==",
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/signature-v4": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
+            "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.55.0.tgz",
+            "integrity": "sha512-FUVrFv6zfHkX1gjwOvam4VneGJL9L/1can5HoNKAsxYwGUMVCrMEmyfkGWBy+paMe0dQ3bF4VVZjJHEvzJaQLQ==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/signature-v4": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
+            "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.55.0.tgz",
+            "integrity": "sha512-UOBimkQrj6onXb3Fyuao85IjipnDSowNHfOOl3ADVX9boA/A4db5QAXBSxThV0WHLArC0iiUsnwu95ElSSMVIg==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.55.0.tgz",
+            "integrity": "sha512-+qpAEWiRXCuY85+VkJWbe+4MfQjlq6Nzi4a+3OejyqTRYMkslK93tR7SejdCiyq1lWpqtbwI9DsjDO45/2P6LA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.55.0.tgz",
+            "integrity": "sha512-yF4YQr72YgVgWO9IDOhDcncqlKUJmMCtserAYhKNvmkVuaMGHE11p+IByWgcIsMJTvtFaFBhTA3W7zhJB1C1xA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/querystring-builder": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
+            "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.55.0.tgz",
+            "integrity": "sha512-vNjjsP5bFuKQMhmuBQZDddH441xanPbm8n42qgfigv0RzgWQhvUFrnmZWLBdyY8geY0RwsQ6x9yfQ0gvs48tpw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
+            "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-uri-escape": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
+            "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
+            "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ==",
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.55.0.tgz",
+            "integrity": "sha512-utmqVMvif8MjSr27HwPDZGCfJGCI4LoFkm4oyjonyu15aTfULm60mX6RTXftaQ2Syf7dnZ2U4kbp3xgzA5ZIgg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.55.0.tgz",
+            "integrity": "sha512-ryJ43HSIVq7wt+QDBlb5CFH/rrH0+LtgnLDU+FM1XAQkT+oo3V9Hzr7rFmnFSfZqr/8hAn/4xUGTaJKZgO57NQ==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-hex-encoding": "3.55.0",
+                "@aws-sdk/util-uri-escape": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
+            "integrity": "sha512-YgBpqg6R3Qg8CH9biOP1N1lYTvh8VLGD6AoDGgy/R1dQSqRQuxgKANLl3DOVcZnIZLsw4TdB0m7U+ZPtirPR1Q==",
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
+            "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ==",
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
+            "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.55.0.tgz",
+            "integrity": "sha512-3hrZ2R/ZyD3IM25KhETOGLC5tB/ft8zoyVmNg1l4+takoUm46ompnglFXCVkWBu9Hpxc+M4XtiY7MHE6es4Wtg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
+            "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
+            "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
+            "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
+            "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-config-provider": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
+            "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
+            "integrity": "sha512-OS3gAwR84bHz7ObhjsSJM+grfeaBq3leGrj7xiX4BH3C8J+c10GMo3fqx1pV8Fq5F+9lMmhHpfOocD63SN5Q8A==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.55.0.tgz",
+            "integrity": "sha512-uIVZ7SVBUrkSH1lqhmvvb0Sc1aecPydGH4ex2qA4Vrp+Xp0h4pzjRELdVEOFbAFMB1uHXzgMV6jLjADGZPrHrQ==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/credential-provider-imds": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.55.0.tgz",
+            "integrity": "sha512-zbDWNzIyqN2Po7SIo1ZDL4rQMP3R0TzGcCrm01bpQAb+2fWqUPigolvNZXXtMO6eS7EW3ZJJzkfoWHdH8zDz1A==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
+            "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
+            "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.55.0.tgz",
+            "integrity": "sha512-E+8PluqbdOKfdJc9E4k0vy4PPb9wvAMa2Zdm5ycoaY0IXRI9RjQJnRw5JKAAJWLuOy7Lb83LgoowGW3o+4AuKw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.55.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.55.0.tgz",
+            "integrity": "sha512-7aoolXzpnTcvIGkxY8v8AZR5ooH7c0wttEjQNkOfORQprznNuj5RUZPxq8oStpFSvwASZJPpfd2Y18G2jPthMw==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
+            "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
+            "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.55.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+        },
+        "node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==",
+            "bin": {
+                "xml2js": "cli.js"
+            },
+            "funding": {
+                "type": "paypal",
+                "url": "https://paypal.me/naturalintelligence"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        }
+    },
+    "dependencies": {
+        "@aws-crypto/ie11-detection": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
+            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "requires": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "requires": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/supports-web-crypto": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
+            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/util": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.1.tgz",
+            "integrity": "sha512-JJmFFwvbm08lULw4Nm5QOLg8+lAQeC8aCXK5xrtxntYzYXCGfHwUJ4Is3770Q7HmICsXthGQ+ZsDL7C2uH3yBQ==",
+            "requires": {
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-sdk/abort-controller": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.55.0.tgz",
+            "integrity": "sha512-rCcTxJDEFnmvo/PgbhCRv24/Uv03lEGfRslKZq7SjaMcOubflS/ZXYaMEgsjYHgAT0zlpSsyCIkJXmhFaM7H7w==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/client-eventbridge": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.55.0.tgz",
+            "integrity": "sha512-6VRYbVPDHr1+PWCHF0khtpTNS5t/cRQzBCr6oIN+iVt8D+HH5A1BKapfpctwq92mTS3B6JxWVsiTlPUU1BtI4w==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.55.0",
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/credential-provider-node": "3.55.0",
+                "@aws-sdk/fetch-http-handler": "3.55.0",
+                "@aws-sdk/hash-node": "3.55.0",
+                "@aws-sdk/invalid-dependency": "3.55.0",
+                "@aws-sdk/middleware-content-length": "3.55.0",
+                "@aws-sdk/middleware-host-header": "3.55.0",
+                "@aws-sdk/middleware-logger": "3.55.0",
+                "@aws-sdk/middleware-retry": "3.55.0",
+                "@aws-sdk/middleware-serde": "3.55.0",
+                "@aws-sdk/middleware-signing": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/middleware-user-agent": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/node-http-handler": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/smithy-client": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "@aws-sdk/util-base64-node": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.55.0",
+                "@aws-sdk/util-defaults-mode-node": "3.55.0",
+                "@aws-sdk/util-user-agent-browser": "3.55.0",
+                "@aws-sdk/util-user-agent-node": "3.55.0",
+                "@aws-sdk/util-utf8-browser": "3.55.0",
+                "@aws-sdk/util-utf8-node": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/client-sso": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.55.0.tgz",
+            "integrity": "sha512-bIGy2xkWZ00Vn5ByLIQamHVbzSE6Pbcs67873otNWtpkygfMzvQRFZ8RB6J+C6BuAwT3xTLI0aNi40RxxwM4HQ==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/fetch-http-handler": "3.55.0",
+                "@aws-sdk/hash-node": "3.55.0",
+                "@aws-sdk/invalid-dependency": "3.55.0",
+                "@aws-sdk/middleware-content-length": "3.55.0",
+                "@aws-sdk/middleware-host-header": "3.55.0",
+                "@aws-sdk/middleware-logger": "3.55.0",
+                "@aws-sdk/middleware-retry": "3.55.0",
+                "@aws-sdk/middleware-serde": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/middleware-user-agent": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/node-http-handler": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/smithy-client": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "@aws-sdk/util-base64-node": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.55.0",
+                "@aws-sdk/util-defaults-mode-node": "3.55.0",
+                "@aws-sdk/util-user-agent-browser": "3.55.0",
+                "@aws-sdk/util-user-agent-node": "3.55.0",
+                "@aws-sdk/util-utf8-browser": "3.55.0",
+                "@aws-sdk/util-utf8-node": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/client-sts": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.55.0.tgz",
+            "integrity": "sha512-/xmx0bxvhL9ffQ7A263MyTAfC6G0cyy/FwTmTWTt2xoKCNub7sGrPCJOjZB5fvmy9FpUvFUOJw1DnCghANKxzw==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/credential-provider-node": "3.55.0",
+                "@aws-sdk/fetch-http-handler": "3.55.0",
+                "@aws-sdk/hash-node": "3.55.0",
+                "@aws-sdk/invalid-dependency": "3.55.0",
+                "@aws-sdk/middleware-content-length": "3.55.0",
+                "@aws-sdk/middleware-host-header": "3.55.0",
+                "@aws-sdk/middleware-logger": "3.55.0",
+                "@aws-sdk/middleware-retry": "3.55.0",
+                "@aws-sdk/middleware-sdk-sts": "3.55.0",
+                "@aws-sdk/middleware-serde": "3.55.0",
+                "@aws-sdk/middleware-signing": "3.55.0",
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/middleware-user-agent": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/node-http-handler": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/smithy-client": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "@aws-sdk/util-base64-node": "3.55.0",
+                "@aws-sdk/util-body-length-browser": "3.55.0",
+                "@aws-sdk/util-body-length-node": "3.55.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.55.0",
+                "@aws-sdk/util-defaults-mode-node": "3.55.0",
+                "@aws-sdk/util-user-agent-browser": "3.55.0",
+                "@aws-sdk/util-user-agent-node": "3.55.0",
+                "@aws-sdk/util-utf8-browser": "3.55.0",
+                "@aws-sdk/util-utf8-node": "3.55.0",
+                "entities": "2.2.0",
+                "fast-xml-parser": "3.19.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/config-resolver": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.55.0.tgz",
+            "integrity": "sha512-dW+UcGu6f+RA1ZsiSpdWUrWwrhevXZeeBtr08X83TP7dK8S6HHv5upX+4es1xou6aMqqin+yHZUVmabvAe/gpg==",
+            "requires": {
+                "@aws-sdk/signature-v4": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-config-provider": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-env": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.55.0.tgz",
+            "integrity": "sha512-4AIIXEdvinLlWNFtrUbUgoB7dkuV04RTcTruVWI4Ub4WSsuSCa72ZU1vqyvcEAOgGGLBmcSaGTWByjiD2sGcGA==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-imds": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.55.0.tgz",
+            "integrity": "sha512-aBOQomxYwNHQSHuOetrER1r13x3tJWNd9Eho2OcGLRioNS6/on2T5ptQI5/pJvAqOWe7LG65k1g3eTf1T8Nf1Q==",
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/url-parser": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-ini": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.55.0.tgz",
+            "integrity": "sha512-f4+8mqJ1xapF9SR90VC+Ho4zlnLPdCgAAm9f7Pauf1/beAk5bkmfLshLwQ5Jo4oEPbWLn1Sdk403kwnxpsnksg==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.55.0",
+                "@aws-sdk/credential-provider-imds": "3.55.0",
+                "@aws-sdk/credential-provider-sso": "3.55.0",
+                "@aws-sdk/credential-provider-web-identity": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.55.0.tgz",
+            "integrity": "sha512-cDAk2+29sZyluk3D2vomCJd0adJxjun9yVdyAiuoutxx9LZ1KQgsDEVHDbPQFpmeOBBagtMNpHNVtUunQ3yy1w==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.55.0",
+                "@aws-sdk/credential-provider-imds": "3.55.0",
+                "@aws-sdk/credential-provider-ini": "3.55.0",
+                "@aws-sdk/credential-provider-process": "3.55.0",
+                "@aws-sdk/credential-provider-sso": "3.55.0",
+                "@aws-sdk/credential-provider-web-identity": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-process": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.55.0.tgz",
+            "integrity": "sha512-09AGJ6bdonXpV/dyHzrQqcbo2oy3aDxjcq+/LGo4GuB0ZHD2TJqKpExU7ie0rg/5OdBnTX6c+9JyjeFt03uX7w==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-sso": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.55.0.tgz",
+            "integrity": "sha512-hKWbZMDY5nZMsOKMVkeUrKCdHaemMhyAH4WfApq976DDJt6bm6U+jvkTspO8qQaIPD8xdRqyi5AMLvVcHjBbTg==",
+            "requires": {
+                "@aws-sdk/client-sso": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.55.0.tgz",
+            "integrity": "sha512-aKnXfZNGohTuF9rCGYLg4JEIOvWIZ/sb66XMq7bOUrx13KRPDwL/eUQL8quS5jGRLpjXVNvrS17AFf65GbdUBg==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/fetch-http-handler": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.55.0.tgz",
+            "integrity": "sha512-/Sta3MLlszpRZ1pg+ClxfNqGvraX93F587eHrfQMaGXgQ2BqJLiAVRorBRGcmmmrHxfLOqspNqufF7ibrqziRQ==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/querystring-builder": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-base64-browser": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/hash-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
+            "integrity": "sha512-2UdYwY/++AlzWEAFaK9wOed2QSxbzV527vmqKjReLHpPKPrSIlooUxlTH3LU6Y6WVDAzDRtLK43KUVXTLgGK1A==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-buffer-from": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/invalid-dependency": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.55.0.tgz",
+            "integrity": "sha512-delH0lV+78fdD/8MXIt9kTLS6IwHvdhqq9dw/ow5VjTUw+xBwUlfPfZplaai+3hKTKWh6a2WZCeDasNItBv9aA==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/is-array-buffer": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.55.0.tgz",
+            "integrity": "sha512-NbiPHVYuPxdqdFd6FxzzN3H1BQn/iWA3ri3Ry7AyLeP/tGs1yzEWMwf8BN8TSMALI0GXT6Sh0GDWy3Ok5xB6DA==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-content-length": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.55.0.tgz",
+            "integrity": "sha512-IkFBwa1G5ERfKFh4Kdtcn/aNAGi3Hcp9IO1PVt69LZWaevxjXAi5NS2k65E9mZPEumzuLtcEeC+3qhPs4FUkqQ==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-host-header": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.55.0.tgz",
+            "integrity": "sha512-69mTWJfuPP4aC+h2/cb9B2CUNA9tiRPUBp67dmMrA2dHyy53kNYo8TGgfLKProoBidBz/AVXIfnh+izJj0F20w==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-logger": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
+            "integrity": "sha512-PtRbVrxEzDmeV9prBIP4/9or7R5Dj66mjbFSvNRGZ0n+UBfBFfVRfNrhQPNzQpfV9A3KVl9YyWCVXDSW+/rk9Q==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-retry": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.55.0.tgz",
+            "integrity": "sha512-Z0j4/zyvgp8Y7HYud1MCqheg9koVh7p1ekS8lm6GePZBWILXsFib8PK9eq7B16u2z7yyz2tHrzwQrHRRr0cQKQ==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/service-error-classification": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.55.0.tgz",
+            "integrity": "sha512-BrK3UXmD08rGbhY6cAHXsQxDfflOrPbKe4gxymlckd9sGIPC42O1KfJQ0CaxWPvG1Gd3R/QFfoPFClpTDhdh0Q==",
+            "requires": {
+                "@aws-sdk/middleware-signing": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/signature-v4": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-serde": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.55.0.tgz",
+            "integrity": "sha512-NkEbTDrSZcC2NhuvfjXHKJEl0xgI2B5tMAwi/rMOq/TEnARwVUL9qAy+5lgeiPCqebiNllWatARrFgAaYf0VeA==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-signing": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.55.0.tgz",
+            "integrity": "sha512-FUVrFv6zfHkX1gjwOvam4VneGJL9L/1can5HoNKAsxYwGUMVCrMEmyfkGWBy+paMe0dQ3bF4VVZjJHEvzJaQLQ==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/signature-v4": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-stack": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.55.0.tgz",
+            "integrity": "sha512-ouD+wFz8W2R0ZQ8HrbhgN8tg1jyINEg9lPEEXY79w1Q5sf94LJ90XKAMVk02rw3dJalUWjLHf0OQe1/qxZfHyA==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-user-agent": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.55.0.tgz",
+            "integrity": "sha512-UOBimkQrj6onXb3Fyuao85IjipnDSowNHfOOl3ADVX9boA/A4db5QAXBSxThV0WHLArC0iiUsnwu95ElSSMVIg==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/node-config-provider": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.55.0.tgz",
+            "integrity": "sha512-+qpAEWiRXCuY85+VkJWbe+4MfQjlq6Nzi4a+3OejyqTRYMkslK93tR7SejdCiyq1lWpqtbwI9DsjDO45/2P6LA==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/shared-ini-file-loader": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/node-http-handler": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.55.0.tgz",
+            "integrity": "sha512-yF4YQr72YgVgWO9IDOhDcncqlKUJmMCtserAYhKNvmkVuaMGHE11p+IByWgcIsMJTvtFaFBhTA3W7zhJB1C1xA==",
+            "requires": {
+                "@aws-sdk/abort-controller": "3.55.0",
+                "@aws-sdk/protocol-http": "3.55.0",
+                "@aws-sdk/querystring-builder": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/property-provider": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.55.0.tgz",
+            "integrity": "sha512-o7cKFJSHq5WOhwPsspYrzNto35oKKZvESZuWDtLxaZKSI6l7zpA366BI4kDG6Tc9i2+teV553MbxyZ9eya5A8g==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/protocol-http": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.55.0.tgz",
+            "integrity": "sha512-vNjjsP5bFuKQMhmuBQZDddH441xanPbm8n42qgfigv0RzgWQhvUFrnmZWLBdyY8geY0RwsQ6x9yfQ0gvs48tpw==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/querystring-builder": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.55.0.tgz",
+            "integrity": "sha512-/ZAXNipt9nRR8k+eowwukE/YjXnQ49p5w/MkaQxsBk3IuIf7MAcgVg8glHr0igH84GfUQ7ZVP8v+G2S3tKUG+Q==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-uri-escape": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/querystring-parser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.55.0.tgz",
+            "integrity": "sha512-e+2FLgo+eDx7oh7ap5HngN9XSVMxredAVztLHxCcSN0lFHHHzMa8b2SpXbaowUxQHh7ziymSqvOrPYFQ71Filg==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/service-error-classification": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
+            "integrity": "sha512-HdjnDyarsa1Avq1MJurkLyEe9c3eRa76dPmK4TmRGgwJ+tInEzGHL0rBW7V8xBK+PDF+fJQ71hvm8jPYmzvBwQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.55.0.tgz",
+            "integrity": "sha512-utmqVMvif8MjSr27HwPDZGCfJGCI4LoFkm4oyjonyu15aTfULm60mX6RTXftaQ2Syf7dnZ2U4kbp3xgzA5ZIgg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/signature-v4": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.55.0.tgz",
+            "integrity": "sha512-ryJ43HSIVq7wt+QDBlb5CFH/rrH0+LtgnLDU+FM1XAQkT+oo3V9Hzr7rFmnFSfZqr/8hAn/4xUGTaJKZgO57NQ==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "@aws-sdk/util-hex-encoding": "3.55.0",
+                "@aws-sdk/util-uri-escape": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/smithy-client": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
+            "integrity": "sha512-YgBpqg6R3Qg8CH9biOP1N1lYTvh8VLGD6AoDGgy/R1dQSqRQuxgKANLl3DOVcZnIZLsw4TdB0m7U+ZPtirPR1Q==",
+            "requires": {
+                "@aws-sdk/middleware-stack": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/types": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.55.0.tgz",
+            "integrity": "sha512-wrDZjuy1CVAYxDCbm3bWQIKMGfNs7XXmG0eG4858Ixgqmq2avsIn5TORy8ynBxcXn9aekV/+tGEQ7BBSYzIVNQ=="
+        },
+        "@aws-sdk/url-parser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.55.0.tgz",
+            "integrity": "sha512-qrTwN5xIgTLreqLnZ+x3cAudjNKfxi6srW1H/px2mk4lb2U9B4fpGjZ6VU+XV8U2kR+YlT8J6Jo5iwuVGfC91A==",
+            "requires": {
+                "@aws-sdk/querystring-parser": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-base64-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.55.0.tgz",
+            "integrity": "sha512-3hrZ2R/ZyD3IM25KhETOGLC5tB/ft8zoyVmNg1l4+takoUm46ompnglFXCVkWBu9Hpxc+M4XtiY7MHE6es4Wtg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-base64-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.55.0.tgz",
+            "integrity": "sha512-UQ/ZuNoAc8CFMpSiRYmevaTsuRKzLwulZTnM8LNlIt9Wx1tpNvqp80cfvVj7yySKROtEi20wq29h31dZf1eYNQ==",
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-body-length-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.55.0.tgz",
+            "integrity": "sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-body-length-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.55.0.tgz",
+            "integrity": "sha512-lU1d4I+9wJwydduXs0SxSfd+mHKjxeyd39VwOv6i2KSwWkPbji9UQqpflKLKw+r45jL7+xU/zfeTUg5Tt/3Gew==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-buffer-from": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.55.0.tgz",
+            "integrity": "sha512-uVzKG1UgvnV7XX2FPTylBujYMKBPBaq/qFBxfl0LVNfrty7YjpfieQxAe6yRLD+T0Kir/WDQwGvYC+tOYG3IGA==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-config-provider": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.55.0.tgz",
+            "integrity": "sha512-30dzofQQfx6tp1jVZkZ0DGRsT0wwC15nEysKRiAcjncM64A0Cm6sra77d0os3vbKiKoPCI/lMsFr4o3533+qvQ==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
+            "integrity": "sha512-OS3gAwR84bHz7ObhjsSJM+grfeaBq3leGrj7xiX4BH3C8J+c10GMo3fqx1pV8Fq5F+9lMmhHpfOocD63SN5Q8A==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.55.0.tgz",
+            "integrity": "sha512-uIVZ7SVBUrkSH1lqhmvvb0Sc1aecPydGH4ex2qA4Vrp+Xp0h4pzjRELdVEOFbAFMB1uHXzgMV6jLjADGZPrHrQ==",
+            "requires": {
+                "@aws-sdk/config-resolver": "3.55.0",
+                "@aws-sdk/credential-provider-imds": "3.55.0",
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/property-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-hex-encoding": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.55.0.tgz",
+            "integrity": "sha512-zbDWNzIyqN2Po7SIo1ZDL4rQMP3R0TzGcCrm01bpQAb+2fWqUPigolvNZXXtMO6eS7EW3ZJJzkfoWHdH8zDz1A==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-locate-window": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
+            "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-uri-escape": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.55.0.tgz",
+            "integrity": "sha512-mmdDLUpFCN2nkfwlLdOM54lTD528GiGSPN1qb8XtGLgZsJUmg3uJSFIN2lPeSbEwJB3NFjVas/rnQC48i7mV8w==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.55.0.tgz",
+            "integrity": "sha512-E+8PluqbdOKfdJc9E4k0vy4PPb9wvAMa2Zdm5ycoaY0IXRI9RjQJnRw5JKAAJWLuOy7Lb83LgoowGW3o+4AuKw==",
+            "requires": {
+                "@aws-sdk/types": "3.55.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-user-agent-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.55.0.tgz",
+            "integrity": "sha512-7aoolXzpnTcvIGkxY8v8AZR5ooH7c0wttEjQNkOfORQprznNuj5RUZPxq8oStpFSvwASZJPpfd2Y18G2jPthMw==",
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.55.0",
+                "@aws-sdk/types": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-utf8-browser": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.55.0.tgz",
+            "integrity": "sha512-ljzqJcyjfJpEVSIAxwtIS8xMRUly84BdjlBXyp6cu4G8TUufgjNS31LWdhyGhgmW5vYBNr+LTz0Kwf6J+ou7Ug==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-utf8-node": {
+            "version": "3.55.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.55.0.tgz",
+            "integrity": "sha512-FsFm7GFaC7j0tlPEm/ri8bU2QCwFW5WKjxUg8lm1oWaxplCpKGUsmcfPJ4sw58GIoyoGu4QXBK60oCWosZYYdQ==",
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.55.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+        },
+        "entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+        },
+        "fast-xml-parser": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+            "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
+        },
+        "tslib": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
     }
 }

--- a/services/crawl/functions/update-status/package.json
+++ b/services/crawl/functions/update-status/package.json
@@ -1,4 +1,7 @@
 {
     "name": "buzzword-aws-update-status-lambda",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "dependencies": {
+        "@aws-sdk/client-eventbridge": "3.55.0"
+    }
 }

--- a/services/crawl/functions/update-status/ports/EventClient.ts
+++ b/services/crawl/functions/update-status/ports/EventClient.ts
@@ -1,0 +1,7 @@
+import { CrawlStatus } from "buzzword-aws-crawl-urls-repository-library";
+
+interface EventClient {
+    sentStatusUpdate(url: string, status: CrawlStatus): Promise<boolean>;
+}
+
+export default EventClient;

--- a/services/crawl/functions/update-status/update-status.ts
+++ b/services/crawl/functions/update-status/update-status.ts
@@ -9,6 +9,8 @@ import {
 } from "./ports/UpdateStatusPrimaryAdapter";
 import UpdateStatusDomain from "./domain/UpdateStatusDomain";
 import UpdateStatusEventAdapter from "./adapters/UpdateStatusEventAdapter";
+import EventClient from "./ports/EventClient";
+import EventBridgeClient from "./adapters/EventBridgeClient";
 
 function createRepository(): Repository {
     if (!process.env.TABLE_NAME) {
@@ -18,8 +20,17 @@ function createRepository(): Repository {
     return new URLsTableRepository(process.env.TABLE_NAME);
 }
 
+function createEventClient(): EventClient {
+    if (!process.env.EVENT_BUS_NAME) {
+        throw new Error("Crawl event bus name has not been set.");
+    }
+
+    return new EventBridgeClient(process.env.EVENT_BUS_NAME);
+}
+
 const repository = createRepository();
-const domain = new UpdateStatusDomain(repository);
+const client = createEventClient();
+const domain = new UpdateStatusDomain(repository, client);
 const adapter = new UpdateStatusEventAdapter(domain);
 
 async function handler(

--- a/services/crawl/schemas/schema.graphql
+++ b/services/crawl/schemas/schema.graphql
@@ -52,4 +52,5 @@ type Subscription {
 enum CrawlStatus {
     STARTED
     COMPLETE
+    FAILED
 }


### PR DESCRIPTION
Resolves #170 

# What

Update Crawl component diagram to reflect update status lambda addition and interactions with DynamoDB and event bus
Update update status lambda to send an crawl status updated event to the crawl service event bus if DynamoDB write was successful
Update crawl service SAM template to allow update status lambda to write events to crawl event bus 
Update Crawl Service GraphQL schema to include failed status type

# Why

To allow clients of the crawl service to be informed about any failures that occur when crawling

