### PR TITLE
Feature/176 UI crawl status

### DIFF
--- a/ui/src/components/CrawlingSpinner.tsx
+++ b/ui/src/components/CrawlingSpinner.tsx
@@ -33,7 +33,7 @@ function CrawlingSpinner(props: CrawlingSpinnerProps) {
         }
     }, [data]);
 
-    return <Spin />;
+    return <Spin tip="Crawling..." />;
 }
 
 export { CrawlingSpinner, CRAWL_STATUS_UPDATE_SUBSCRIPTION };

--- a/ui/src/components/CrawlingSpinner.tsx
+++ b/ui/src/components/CrawlingSpinner.tsx
@@ -1,10 +1,12 @@
-import React, { Fragment } from "react";
+import React, { useEffect } from "react";
 import { gql, useSubscription } from "@apollo/client";
+import { Spin } from "antd";
 
 import CrawlStatus from "../enums/CrawlStatus";
 
 type CrawlingSpinnerProps = {
     url: string;
+    onStatusUpdate: (status: CrawlStatus) => unknown;
 };
 
 type CrawlStatusUpdate = {
@@ -20,12 +22,18 @@ const CRAWL_STATUS_UPDATE_SUBSCRIPTION = gql`
 `;
 
 function CrawlingSpinner(props: CrawlingSpinnerProps) {
-    useSubscription<{ crawlStatusUpdated: CrawlStatusUpdate }, { url: string }>(
-        CRAWL_STATUS_UPDATE_SUBSCRIPTION,
-        { variables: { url: props.url } }
-    );
+    const { data } = useSubscription<
+        { crawlStatusUpdated: CrawlStatusUpdate },
+        { url: string }
+    >(CRAWL_STATUS_UPDATE_SUBSCRIPTION, { variables: { url: props.url } });
 
-    return <Fragment />;
+    useEffect(() => {
+        if (data?.crawlStatusUpdated.status) {
+            props.onStatusUpdate(data.crawlStatusUpdated.status);
+        }
+    }, [data]);
+
+    return <Spin />;
 }
 
 export { CrawlingSpinner, CRAWL_STATUS_UPDATE_SUBSCRIPTION };

--- a/ui/src/components/CrawlingSpinner.tsx
+++ b/ui/src/components/CrawlingSpinner.tsx
@@ -1,0 +1,31 @@
+import React, { Fragment } from "react";
+import { gql, useSubscription } from "@apollo/client";
+
+import CrawlStatus from "../enums/CrawlStatus";
+
+type CrawlingSpinnerProps = {
+    url: string;
+};
+
+type CrawlStatusUpdate = {
+    status: CrawlStatus;
+};
+
+const CRAWL_STATUS_UPDATE_SUBSCRIPTION = gql`
+    subscription CrawlStatusUpdated($url: ID!) {
+        crawlStatusUpdated(id: $url) {
+            status
+        }
+    }
+`;
+
+function CrawlingSpinner(props: CrawlingSpinnerProps) {
+    useSubscription<{ crawlStatusUpdated: CrawlStatusUpdate }, { url: string }>(
+        CRAWL_STATUS_UPDATE_SUBSCRIPTION,
+        { variables: { url: props.url } }
+    );
+
+    return <Fragment />;
+}
+
+export { CrawlingSpinner, CRAWL_STATUS_UPDATE_SUBSCRIPTION };

--- a/ui/src/components/Search.tsx
+++ b/ui/src/components/Search.tsx
@@ -43,6 +43,9 @@ function Search() {
 
     const handleCrawlStatusUpdate = (status: CrawlStatus) => {
         setCrawlStatus(status);
+        if (status == CrawlStatus.FAILED) {
+            setCrawledURL(undefined);
+        }
     };
 
     if (crawlStatus == CrawlStatus.COMPLETE && crawledURL) {

--- a/ui/src/components/Search.tsx
+++ b/ui/src/components/Search.tsx
@@ -28,7 +28,7 @@ function Search() {
         { input: StartCrawlInput }
     >(START_CRAWL_MUTATION);
     const [crawledURL, setCrawledURL] = useState<URL | undefined>();
-    const [crawlComplete, setCrawlComplete] = useState<boolean>(false);
+    const [crawlStatus, setCrawlStatus] = useState<CrawlStatus | undefined>();
 
     const handleURLSubmit = async (validatedURL: URL) => {
         setCrawledURL(validatedURL);
@@ -42,12 +42,10 @@ function Search() {
     };
 
     const handleCrawlStatusUpdate = (status: CrawlStatus) => {
-        if (status == CrawlStatus.COMPLETE) {
-            setCrawlComplete(true);
-        }
+        setCrawlStatus(status);
     };
 
-    if (crawlComplete && crawledURL) {
+    if (crawlStatus == CrawlStatus.COMPLETE && crawledURL) {
         return (
             <Navigate
                 to={`/results/${encodeURIComponent(crawledURL.toString())}`}
@@ -63,10 +61,11 @@ function Search() {
                     url={crawledURL.hostname}
                 />
             )}
-            {!data?.startCrawl.started && (
+            {(!data?.startCrawl.started ||
+                crawlStatus == CrawlStatus.FAILED) && (
                 <URLInput onURLSubmit={handleURLSubmit} />
             )}
-            {error && (
+            {(error || crawlStatus == CrawlStatus.FAILED) && (
                 <p>
                     An error occurred when searching for buzzwords, please try
                     again.

--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -7,10 +7,10 @@ import App from "../App";
 import {
     renderWithMockProvider,
     createStatusUpdateMock,
+    createStartCrawlMock,
 } from "./helpers/utils";
 import KeyphraseServiceClientFactory from "../../clients/interfaces/KeyphraseServiceClientFactory";
 import { KeyphraseServiceClient } from "../../clients/interfaces/KeyphraseServiceClient";
-import { START_CRAWL_MUTATION } from "../Search";
 import CrawlStatus from "../../enums/CrawlStatus";
 
 const APPLICATION_TITLE = "How many buzzwords";
@@ -126,17 +126,10 @@ test("navigates to results page if crawl successfully completes", async () => {
         VALID_URL.hostname
     );
     const expectedHeader = `Results for: ${VALID_URL}`;
-    const hostnameMutationMock = {
-        request: {
-            query: START_CRAWL_MUTATION,
-            variables: { input: { url: VALID_URL.hostname } },
-        },
-        result: jest.fn(() => ({
-            data: {
-                startCrawl: { started: true },
-            },
-        })),
-    };
+    const hostnameStartCrawlMock = createStartCrawlMock(
+        true,
+        VALID_URL.hostname
+    );
 
     mockKeyphraseClientFactory.createClient.mockReturnValue(
         mockKeyphraseClient
@@ -145,7 +138,7 @@ test("navigates to results page if crawl successfully completes", async () => {
 
     const { getByRole } = renderWithMockProvider(
         <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />,
-        [hostnameMutationMock, completedSubscriptionMock]
+        [hostnameStartCrawlMock, completedSubscriptionMock]
     );
     fireEvent.input(getByRole("textbox", { name: URL_INPUT_LABEL }), {
         target: { value: VALID_URL },

--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -3,11 +3,15 @@ import { fireEvent, waitFor } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { from } from "rxjs";
 
-import { renderWithMockProvider } from "./helpers/utils";
 import App from "../App";
+import {
+    renderWithMockProvider,
+    createStatusUpdateMock,
+} from "./helpers/utils";
 import KeyphraseServiceClientFactory from "../../clients/interfaces/KeyphraseServiceClientFactory";
 import { KeyphraseServiceClient } from "../../clients/interfaces/KeyphraseServiceClient";
 import { START_CRAWL_MUTATION } from "../Search";
+import CrawlStatus from "../../enums/CrawlStatus";
 
 const APPLICATION_TITLE = "How many buzzwords";
 const URL_INPUT_LABEL = "URL";
@@ -116,7 +120,11 @@ test.each([
     }
 );
 
-test("navigates to results page if crawl successfully initiates", async () => {
+test("navigates to results page if crawl successfully completes", async () => {
+    const completedSubscriptionMock = createStatusUpdateMock(
+        CrawlStatus.COMPLETE,
+        VALID_URL.hostname
+    );
     const expectedHeader = `Results for: ${VALID_URL}`;
     const hostnameMutationMock = {
         request: {
@@ -137,7 +145,7 @@ test("navigates to results page if crawl successfully initiates", async () => {
 
     const { getByRole } = renderWithMockProvider(
         <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />,
-        [hostnameMutationMock]
+        [hostnameMutationMock, completedSubscriptionMock]
     );
     fireEvent.input(getByRole("textbox", { name: URL_INPUT_LABEL }), {
         target: { value: VALID_URL },

--- a/ui/src/components/__tests__/CrawlingSpinner.test.tsx
+++ b/ui/src/components/__tests__/CrawlingSpinner.test.tsx
@@ -1,37 +1,23 @@
 import React from "react";
 import { waitFor } from "@testing-library/react";
 
-import { renderWithMockProvider } from "./helpers/utils";
 import {
-    CrawlingSpinner,
-    CRAWL_STATUS_UPDATE_SUBSCRIPTION,
-} from "../CrawlingSpinner";
+    createStatusUpdateMock,
+    renderWithMockProvider,
+} from "./helpers/utils";
+import { CrawlingSpinner } from "../CrawlingSpinner";
 import CrawlStatus from "../../enums/CrawlStatus";
 
 const VALID_URL = "www.example.com";
 
 const MOCK_STATUS_UPDATE = jest.fn();
 
-function createStatusUpdateMock(mockStatus: CrawlStatus) {
-    return {
-        request: {
-            query: CRAWL_STATUS_UPDATE_SUBSCRIPTION,
-            variables: { url: VALID_URL },
-        },
-        result: jest.fn(() => ({
-            data: {
-                crawlStatusUpdated: { status: mockStatus },
-            },
-        })),
-    };
-}
-
 beforeEach(() => {
     MOCK_STATUS_UPDATE.mockClear();
 });
 
 test("subscribes to crawl status updates given a valid URL", async () => {
-    const mock = createStatusUpdateMock(CrawlStatus.STARTED);
+    const mock = createStatusUpdateMock(CrawlStatus.STARTED, VALID_URL);
 
     renderWithMockProvider(
         <CrawlingSpinner url={VALID_URL} onStatusUpdate={jest.fn()} />,
@@ -49,7 +35,7 @@ test.each(Object.values(CrawlStatus))(
                 url={VALID_URL}
                 onStatusUpdate={MOCK_STATUS_UPDATE}
             />,
-            [createStatusUpdateMock(status)]
+            [createStatusUpdateMock(status, VALID_URL)]
         );
 
         await waitFor(() =>

--- a/ui/src/components/__tests__/CrawlingSpinner.test.tsx
+++ b/ui/src/components/__tests__/CrawlingSpinner.test.tsx
@@ -67,3 +67,14 @@ test("does not call on status update if no crawl status is given", async () => {
 
     await waitFor(() => expect(MOCK_STATUS_UPDATE).not.toHaveBeenCalled());
 });
+
+test("displays crawling message", async () => {
+    const expectedMessage = "Crawling...";
+
+    const { getByText } = renderWithMockProvider(
+        <CrawlingSpinner url={VALID_URL} onStatusUpdate={MOCK_STATUS_UPDATE} />,
+        []
+    );
+
+    await waitFor(() => expect(getByText(expectedMessage)).toBeInTheDocument());
+});

--- a/ui/src/components/__tests__/CrawlingSpinner.test.tsx
+++ b/ui/src/components/__tests__/CrawlingSpinner.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { waitFor } from "@testing-library/react";
+
+import { renderWithMockProvider } from "./helpers/utils";
+import {
+    CrawlingSpinner,
+    CRAWL_STATUS_UPDATE_SUBSCRIPTION,
+} from "../CrawlingSpinner";
+import CrawlStatus from "../../enums/CrawlStatus";
+
+const VALID_URL = "www.example.com";
+
+const HOSTNAME_CRAWL_STARTED_STATUS_UPDATE_MOCK = {
+    request: {
+        query: CRAWL_STATUS_UPDATE_SUBSCRIPTION,
+        variables: { url: VALID_URL },
+    },
+    result: jest.fn(() => ({
+        data: {
+            crawlStatusUpdated: { status: CrawlStatus.STARTED },
+        },
+    })),
+};
+
+test("subscribes to crawl status updates given a valid URL", async () => {
+    renderWithMockProvider(<CrawlingSpinner url={VALID_URL} />, [
+        HOSTNAME_CRAWL_STARTED_STATUS_UPDATE_MOCK,
+    ]);
+
+    await waitFor(() =>
+        expect(
+            HOSTNAME_CRAWL_STARTED_STATUS_UPDATE_MOCK.result
+        ).toHaveBeenCalled()
+    );
+});

--- a/ui/src/components/__tests__/Search.test.tsx
+++ b/ui/src/components/__tests__/Search.test.tsx
@@ -43,6 +43,12 @@ describe("field rendering", () => {
             getByRole("button", { name: SEARCH_BUTTON_TEXT })
         ).toBeInTheDocument();
     });
+
+    test("does not display the crawling message", () => {
+        const { queryByText } = renderWithMockProvider(<Search />);
+
+        expect(queryByText(CRAWLING_MESSAGE)).not.toBeInTheDocument();
+    });
 });
 
 test("calls crawl service to initiate call given a valid URL", async () => {

--- a/ui/src/components/__tests__/Search.test.tsx
+++ b/ui/src/components/__tests__/Search.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import {
     renderWithMockProvider,
     createStatusUpdateMock,
+    createStartCrawlMock,
 } from "./helpers/utils";
 import { Search, START_CRAWL_MUTATION } from "../Search";
 import CrawlStatus from "../../enums/CrawlStatus";
@@ -16,20 +17,6 @@ const CRAWLING_MESSAGE = "Crawling...";
 
 const VALID_URL = new URL("http://www.example.com/");
 const INVALID_URL = "not a valid URL";
-
-function createStartCrawlMock(started: boolean, url: string) {
-    return {
-        request: {
-            query: START_CRAWL_MUTATION,
-            variables: { input: { url } },
-        },
-        result: jest.fn(() => ({
-            data: {
-                startCrawl: { started },
-            },
-        })),
-    };
-}
 
 const HOSTNAME_START_CRAWL_MOCK = createStartCrawlMock(
     true,

--- a/ui/src/components/__tests__/helpers/utils.tsx
+++ b/ui/src/components/__tests__/helpers/utils.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { render } from "@testing-library/react";
 
+import { CRAWL_STATUS_UPDATE_SUBSCRIPTION } from "../../CrawlingSpinner";
+import CrawlStatus from "../../../enums/CrawlStatus";
+
 function renderWithMockProvider(
     component: React.ReactNode,
     mocks?: MockedResponse<Record<string, unknown>>[]
@@ -13,4 +16,18 @@ function renderWithMockProvider(
     );
 }
 
-export { renderWithMockProvider };
+function createStatusUpdateMock(mockStatus: CrawlStatus, expectedURL: string) {
+    return {
+        request: {
+            query: CRAWL_STATUS_UPDATE_SUBSCRIPTION,
+            variables: { url: expectedURL },
+        },
+        result: jest.fn(() => ({
+            data: {
+                crawlStatusUpdated: { status: mockStatus },
+            },
+        })),
+    };
+}
+
+export { renderWithMockProvider, createStatusUpdateMock };

--- a/ui/src/components/__tests__/helpers/utils.tsx
+++ b/ui/src/components/__tests__/helpers/utils.tsx
@@ -3,6 +3,7 @@ import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { render } from "@testing-library/react";
 
 import { CRAWL_STATUS_UPDATE_SUBSCRIPTION } from "../../CrawlingSpinner";
+import { START_CRAWL_MUTATION } from "../../Search";
 import CrawlStatus from "../../../enums/CrawlStatus";
 
 function renderWithMockProvider(
@@ -30,4 +31,18 @@ function createStatusUpdateMock(mockStatus: CrawlStatus, expectedURL: string) {
     };
 }
 
-export { renderWithMockProvider, createStatusUpdateMock };
+function createStartCrawlMock(started: boolean, url: string) {
+    return {
+        request: {
+            query: START_CRAWL_MUTATION,
+            variables: { input: { url } },
+        },
+        result: jest.fn(() => ({
+            data: {
+                startCrawl: { started },
+            },
+        })),
+    };
+}
+
+export { renderWithMockProvider, createStatusUpdateMock, createStartCrawlMock };

--- a/ui/src/enums/CrawlStatus.ts
+++ b/ui/src/enums/CrawlStatus.ts
@@ -1,0 +1,7 @@
+enum CrawlStatus {
+    COMPLETE = "COMPLETE",
+    STARTED = "STARTED",
+    FAILED = "FAILED",
+}
+
+export default CrawlStatus;


### PR DESCRIPTION
Resolves #176 

# What

Add CrawlingSpinner component to subscribe to crawl status update for given URL, display spinner and call parent component if status updates
Update Search.tsx to: 
- Display Crawling Spinner while the crawl status is not complete or failed
- Navigate to results page when crawl status is complete
- Display error message when crawl status is failed

# Why

To provide better feedback to the user about the state of the crawl.
- Previously if a crawl failed after initiation, there would be no way of knowing on the UI, other than the keyphrase results never arriving