### PR TITLE
Feature/181 crawl service client lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ jobs:
         uses: ./.github/workflows/package.yml
         with:
             path: ./packages/object-validator
+    build-deploy-crawl-client-package:
+        name: Crawl Client Package
+        uses: ./.github/workflows/package.yml
+        with:
+            path: ./packages/crawl-client
     build-deploy-crawl-service:
         name: Crawl Service
         uses: ./.github/workflows/service.yml

--- a/helpers/http-mock.ts
+++ b/helpers/http-mock.ts
@@ -8,7 +8,6 @@ function mockURLFromFile(
     pathname: string,
     filePath: PathOrFileDescriptor,
     persist: boolean,
-    statusCode = 200,
     queryParams?:
         | string
         | boolean
@@ -27,14 +26,11 @@ function mockURLFromFile(
         ? nock(matcher, options).get(pathname).query(queryParams)
         : nock(matcher, options).get(pathname);
 
-    const mockScope: nock.Scope =
-        statusCode == 200
-            ? mockInterceptor.reply(
-                  statusCode,
-                  readFileSync(filePath),
-                  replyHeaders
-              )
-            : mockInterceptor.reply(statusCode);
+    const mockScope: nock.Scope = mockInterceptor.reply(
+        200,
+        readFileSync(filePath),
+        replyHeaders
+    );
 
     if (persist) {
         mockScope.persist();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     projects: [
         "<rootDir>/packages/object-validator",
+        "<rootDir>/packages/crawl-client",
         "<rootDir>/services/crawl",
         "<rootDir>/services/keyphrase",
         "<rootDir>/ui",

--- a/packages/crawl-client/README.md
+++ b/packages/crawl-client/README.md
@@ -1,0 +1,3 @@
+# Crawl Client
+
+Basic HTTP client for the crawl service. Implemented in TypeScript using Axios.

--- a/packages/crawl-client/client/CrawlHTTPClient.ts
+++ b/packages/crawl-client/client/CrawlHTTPClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from "axios";
+
 import CrawlClient from "../interface/CrawlClient";
 
 class CrawlHTTPClient implements CrawlClient {

--- a/packages/crawl-client/client/CrawlHTTPClient.ts
+++ b/packages/crawl-client/client/CrawlHTTPClient.ts
@@ -1,0 +1,18 @@
+import axios, { AxiosInstance } from "axios";
+import CrawlClient from "../interface/CrawlClient";
+
+class CrawlHTTPClient implements CrawlClient {
+    private client: AxiosInstance;
+
+    constructor(serviceEndpoint: URL) {
+        this.client = axios.create({ baseURL: serviceEndpoint.toString() });
+    }
+
+    async getContent(url: URL): Promise<string> {
+        const encodedURL = encodeURIComponent(url.toString());
+        const response = await this.client.get(`/content?url=${encodedURL}`);
+        return response.data;
+    }
+}
+
+export default CrawlHTTPClient;

--- a/packages/crawl-client/client/__tests__/CrawlHTTPClient.test.ts
+++ b/packages/crawl-client/client/__tests__/CrawlHTTPClient.test.ts
@@ -25,7 +25,6 @@ test("calls GET content on the crawl service with encoded url in query string", 
         EXPECTED_CONTENT_PATH,
         CONTENT_ASSET,
         false,
-        200,
         {
             [EXPECTED_CONTENT_URL_QUERY_STRING_PARAM]: encodeURIComponent(
                 VALID_CONTENT_URL.toString()
@@ -46,7 +45,6 @@ test("returns received HTML as string", async () => {
         EXPECTED_CONTENT_PATH,
         CONTENT_ASSET,
         false,
-        200,
         {
             [EXPECTED_CONTENT_URL_QUERY_STRING_PARAM]: encodeURIComponent(
                 VALID_CONTENT_URL.toString()

--- a/packages/crawl-client/client/__tests__/CrawlHTTPClient.test.ts
+++ b/packages/crawl-client/client/__tests__/CrawlHTTPClient.test.ts
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import nock from "nock";
 import path from "path";
 
 import { mockURLFromFile } from "../../../../helpers/http-mock";
@@ -13,6 +14,10 @@ const EXPECTED_CONTENT_PATH = "/content";
 const EXPECTED_CONTENT_URL_QUERY_STRING_PARAM = "url";
 
 const client = new CrawlHTTPClient(VALID_SERVICE_URL);
+
+beforeEach(() => {
+    nock.cleanAll();
+});
 
 test("calls GET content on the crawl service with encoded url in query string", async () => {
     const urlMock = mockURLFromFile(
@@ -53,4 +58,42 @@ test("returns received HTML as string", async () => {
     const actual = await client.getContent(VALID_CONTENT_URL);
 
     expect(actual).toEqual(expectedContent);
+});
+
+test("throws an error if a error occurs while obtaining content", async () => {
+    const expectedError = "test error";
+    nock(VALID_SERVICE_URL.toString(), {
+        encodedQueryParams: true,
+    })
+        .get(EXPECTED_CONTENT_PATH)
+        .query({
+            [EXPECTED_CONTENT_URL_QUERY_STRING_PARAM]: encodeURIComponent(
+                VALID_CONTENT_URL.toString()
+            ),
+        })
+        .replyWithError(expectedError);
+
+    expect.assertions(1);
+    await expect(() => client.getContent(VALID_CONTENT_URL)).rejects.toThrow(
+        expectedError
+    );
+});
+
+test("throws an error if a non-200 response is returned while obtaining content", async () => {
+    const expectedError = "Request failed with status code 404";
+    nock(VALID_SERVICE_URL.toString(), {
+        encodedQueryParams: true,
+    })
+        .get(EXPECTED_CONTENT_PATH)
+        .query({
+            [EXPECTED_CONTENT_URL_QUERY_STRING_PARAM]: encodeURIComponent(
+                VALID_CONTENT_URL.toString()
+            ),
+        })
+        .reply(404);
+
+    expect.assertions(1);
+    await expect(() => client.getContent(VALID_CONTENT_URL)).rejects.toThrow(
+        expectedError
+    );
 });

--- a/packages/crawl-client/client/__tests__/CrawlHTTPClient.test.ts
+++ b/packages/crawl-client/client/__tests__/CrawlHTTPClient.test.ts
@@ -1,0 +1,56 @@
+import fs from "fs-extra";
+import path from "path";
+
+import { mockURLFromFile } from "../../../../helpers/http-mock";
+import CrawlHTTPClient from "../CrawlHTTPClient";
+
+const CONTENT_ASSET = path.join(__dirname, "/assets/", "valid.html");
+
+const VALID_SERVICE_URL = new URL("https://www.example.com/");
+const VALID_CONTENT_URL = new URL("https://www.test.com/");
+
+const EXPECTED_CONTENT_PATH = "/content";
+const EXPECTED_CONTENT_URL_QUERY_STRING_PARAM = "url";
+
+const client = new CrawlHTTPClient(VALID_SERVICE_URL);
+
+test("calls GET content on the crawl service with encoded url in query string", async () => {
+    const urlMock = mockURLFromFile(
+        VALID_SERVICE_URL,
+        EXPECTED_CONTENT_PATH,
+        CONTENT_ASSET,
+        false,
+        200,
+        {
+            [EXPECTED_CONTENT_URL_QUERY_STRING_PARAM]: encodeURIComponent(
+                VALID_CONTENT_URL.toString()
+            ),
+        },
+        { encodedQueryParams: true }
+    );
+
+    await client.getContent(VALID_CONTENT_URL);
+
+    expect(urlMock.isDone()).toBe(true);
+});
+
+test("returns received HTML as string", async () => {
+    const expectedContent = fs.readFileSync(CONTENT_ASSET).toString();
+    mockURLFromFile(
+        VALID_SERVICE_URL,
+        EXPECTED_CONTENT_PATH,
+        CONTENT_ASSET,
+        false,
+        200,
+        {
+            [EXPECTED_CONTENT_URL_QUERY_STRING_PARAM]: encodeURIComponent(
+                VALID_CONTENT_URL.toString()
+            ),
+        },
+        { encodedQueryParams: true }
+    );
+
+    const actual = await client.getContent(VALID_CONTENT_URL);
+
+    expect(actual).toEqual(expectedContent);
+});

--- a/packages/crawl-client/client/__tests__/assets/valid.html
+++ b/packages/crawl-client/client/__tests__/assets/valid.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <p>A valid HTML page, woo!</p>
+    </body>
+</html>

--- a/packages/crawl-client/index.ts
+++ b/packages/crawl-client/index.ts
@@ -1,0 +1,4 @@
+import CrawlClient from "./interface/CrawlClient";
+import CrawlHTTPClient from "./client/CrawlHTTPClient";
+
+export { CrawlClient, CrawlHTTPClient };

--- a/packages/crawl-client/interface/CrawlClient.ts
+++ b/packages/crawl-client/interface/CrawlClient.ts
@@ -1,0 +1,5 @@
+interface CrawlClient {
+    getContent(url: URL): Promise<string>;
+}
+
+export default CrawlClient;

--- a/packages/crawl-client/jest.config.js
+++ b/packages/crawl-client/jest.config.js
@@ -1,0 +1,10 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+    preset: "ts-jest/presets/js-with-ts",
+    testEnvironment: "node",
+    modulePathIgnorePatterns: [
+        ".npm-cache",
+        "node_modules",
+        "__tests__/helpers",
+    ],
+};

--- a/packages/crawl-client/package-lock.json
+++ b/packages/crawl-client/package-lock.json
@@ -1,0 +1,172 @@
+{
+    "name": "@ashley-evans/crawl-client",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "@ashley-evans/crawl-client",
+            "version": "1.0.0",
+            "peerDependencies": {
+                "axios": "^0.27.2"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "peer": true
+        },
+        "node_modules/axios": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "peer": true,
+            "dependencies": {
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
+            }
+        },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "peer": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "peer": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "peer": true,
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        }
+    },
+    "dependencies": {
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "peer": true
+        },
+        "axios": {
+            "version": "0.27.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+            "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+            "peer": true,
+            "requires": {
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
+            }
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "peer": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "peer": true
+        },
+        "follow-redirects": {
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "peer": true
+        },
+        "form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "peer": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "peer": true
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "peer": true,
+            "requires": {
+                "mime-db": "1.52.0"
+            }
+        }
+    }
+}

--- a/packages/crawl-client/package.json
+++ b/packages/crawl-client/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@ashley-evans/crawl-client",
+    "version": "1.0.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ashley-evans/how-many-buzzwords.git"
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    },
+    "main": "./index.js",
+    "peerDependencies": {
+        "axios": "^0.27.2"
+    }
+}

--- a/packages/crawl-client/tsconfig.build.json
+++ b/packages/crawl-client/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ""
+    }
+}

--- a/packages/crawl-client/tsconfig.json
+++ b/packages/crawl-client/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.build.json",
+    "exclude": []
+}

--- a/packages/crawl-client/tsconfig.json
+++ b/packages/crawl-client/tsconfig.json
@@ -1,4 +1,9 @@
 {
     "extends": "./tsconfig.build.json",
-    "exclude": []
+    "exclude": [],
+    "references": [
+        {
+            "path": "../../helpers"
+        }
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
             "path": "packages/object-validator"
         },
         {
+            "path": "packages/crawl-client"
+        },
+        {
             "path": "services/crawl"
         },
         {


### PR DESCRIPTION
Resolves #181 

# What

Added crawl client package with HTTP client implementation for GET content endpoint
Updated http-mock to:
- Enable matching on query string params
- Enable nock options to be passed to nock interceptor creation

Updated ci.yml to include crawl client reusable workflow definition for build/test/deployment of crawl client lib

# Why

To provide a simple implementation for clients to access the crawl service's content endpoint without having to write their own implementation