### PR TITLE
fix/crawl-client-package-rename

### DIFF
--- a/packages/crawl-client/package-lock.json
+++ b/packages/crawl-client/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@ashley-evans/crawl-client",
+    "name": "@ashley-evans/buzzword-crawl-client",
     "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@ashley-evans/crawl-client",
+            "name": "@ashley-evans/buzzword-crawl-client",
             "version": "1.0.0",
             "peerDependencies": {
                 "axios": "^0.27.2"

--- a/packages/crawl-client/package.json
+++ b/packages/crawl-client/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@ashley-evans/crawl-client",
+    "name": "@ashley-evans/buzzword-crawl-client",
     "version": "1.0.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
# What

Updated package.json to prefix crawl client package name with buzzword

# Why

To match naming convention used on other packages in repository