### PR TITLE
Fix/new connection timeout

### DIFF
--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -470,7 +470,7 @@ Resources:
             CodeUri: ./functions/new-connection
             Description: Provides new connections with current database state
             Timeout: 10
-            MemorySize: 256
+            MemorySize: 1024
             Layers:
                 - Ref: KeyphraseRepositoryLibraryLayer
                 - Ref: WebSocketClientLibraryLayer

--- a/services/keyphrase/libs/web-socket-client-library/clients/AWSWebSocketClient.ts
+++ b/services/keyphrase/libs/web-socket-client-library/clients/AWSWebSocketClient.ts
@@ -58,7 +58,7 @@ class AWSWebSocketClient implements WebSocketClient {
         try {
             await this.client.send(new PostToConnectionCommand(input));
             console.log(
-                `Successfully sent data: ${data} to connection ID: ${connectionID}`
+                `Successfully sent data to connection ID: ${connectionID}`
             );
 
             return true;
@@ -72,7 +72,7 @@ class AWSWebSocketClient implements WebSocketClient {
             }
 
             console.error(
-                `An error occurred while sending data: ${data} to connection ID: ${connectionID}. Error: "${ex}"`
+                `An error occurred while sending data to connection ID: ${connectionID}. Error: "${ex}"`
             );
 
             throw ex;


### PR DESCRIPTION
# What

Updated NewConnectionsDomain to chunk occurrences into chunks of 100
Updated NewConnections lambda to have 1024 MB of memory

# Why

The lambda was previously timing out while obtaining the keyphrase occurrences from DynamoDB, increasing the memory size of the lambda fixed the issue
Lambda was unable to send messages to client as messages were going over 32KB limit for messages sent via AWS Web Socket API Gateway 