### PR TITLE
Feature/192 keyphrase word cloud

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,3 +15,9 @@ storage/
 # TSC Output
 
 dist/
+
+# Playwright
+
+test-results/
+playwright-report/
+**/playwright/.cache/

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -120,9 +120,30 @@ jobs:
             - name: Run Unit Tests
               run: |
                   ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose
+    browser-component-test:
+        runs on: ubuntu-latest
+        needs: changed
+        if: ${{ needs.changed.outputs.ui == 'true' }}
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: "16"
+                  scope: "@ashley-evans"
+                  registry-url: "https://npm.pkg.github.com"
+            - name: Install Dependencies
+              run: |
+                  npm ci
+                  npm --prefix ${{ inputs.path }} ci
+                  npx playwright install-deps chromium
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Run Browser Component Tests
+              run: |
+                  npm --prefix ${{ inputs.path }} run test-ct
     deploy:
         runs-on: ubuntu-latest
-        needs: [audit, build, format, lint, unit-test]
+        needs: [audit, build, format, lint, unit-test, browser-component-test]
         if: ${{ github.ref == 'refs/heads/master' }}
         permissions:
             id-token: write

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -135,7 +135,7 @@ jobs:
               run: |
                   npm ci
                   npm --prefix ${{ inputs.path }} ci
-                  npx playwright install-deps chromium
+                  npx playwright install
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Run Browser Component Tests

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -121,7 +121,7 @@ jobs:
               run: |
                   ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose
     browser-component-test:
-        runs on: ubuntu-latest
+        runs-on: ubuntu-latest
         needs: changed
         if: ${{ needs.changed.outputs.ui == 'true' }}
         steps:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ out/
 # Auto-generated files
 
 schema.d.ts
+
+# Playwright
+
+test-results/
+playwright-report/
+**/playwright/.cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,9 @@ dist/
 # Auto-generated files
 
 schema.d.ts
+
+# Playwright
+
+test-results/
+playwright-report/
+**/playwright/.cache/

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -2,12 +2,8 @@
 module.exports = {
     preset: "ts-jest/presets/js-with-ts",
     testEnvironment: "jsdom",
-    modulePathIgnorePatterns: [
-        ".npm-cache",
-        "node_modules",
-        "__tests__/helpers",
-        "tests",
-    ],
+    modulePathIgnorePatterns: ["__tests__/helpers"],
+    roots: ["src"],
     runner: "groups",
     setupFilesAfterEnv: ["<rootDir>/config/jest-setup.ts"],
     moduleNameMapper: {

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
         ".npm-cache",
         "node_modules",
         "__tests__/helpers",
+        "tests",
     ],
     runner: "groups",
     setupFilesAfterEnv: ["<rootDir>/config/jest-setup.ts"],

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,6 +8,7 @@
             "name": "how-many-buzzwords-ui",
             "version": "1.0.0",
             "dependencies": {
+                "@ant-design/plots": "1.2.1",
                 "@apollo/client": "3.6.9",
                 "@ashley-evans/buzzword-object-validator": "1.0.0",
                 "@aws-amplify/auth": "4.5.9",
@@ -27,6 +28,7 @@
                 "@babel/preset-env": "^7.18.2",
                 "@babel/preset-react": "^7.17.12",
                 "@babel/preset-typescript": "^7.17.12",
+                "@playwright/experimental-ct-react": "^1.25.0",
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^13.3.0",
                 "@types/react": "^18.0.9",
@@ -93,6 +95,19 @@
             "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz",
             "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
         },
+        "node_modules/@ant-design/plots": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@ant-design/plots/-/plots-1.2.1.tgz",
+            "integrity": "sha512-wbcmhHRkVi7IFyqzVNUozcJtIpgWHOFHbny5T+DLQoE2lzh+A1nTOfhlPJXc6aq56uIg6w+4iN/umsJKUmcLPw==",
+            "dependencies": {
+                "@antv/g2plot": "^2.2.11",
+                "react-content-loader": "^5.0.4"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.4",
+                "react-dom": ">=16.8.4"
+            }
+        },
         "node_modules/@ant-design/react-slick": {
             "version": "0.29.2",
             "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.29.2.tgz",
@@ -106,6 +121,223 @@
             },
             "peerDependencies": {
                 "react": ">=16.9.0"
+            }
+        },
+        "node_modules/@antv/adjust": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@antv/adjust/-/adjust-0.2.5.tgz",
+            "integrity": "sha512-MfWZOkD9CqXRES6MBGRNe27Q577a72EIwyMnE29wIlPliFvJfWwsrONddpGU7lilMpVKecS3WAzOoip3RfPTRQ==",
+            "dependencies": {
+                "@antv/util": "~2.0.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@antv/adjust/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@antv/attr": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@antv/attr/-/attr-0.3.3.tgz",
+            "integrity": "sha512-7iSSRhYzZ7pYXZKTL1ECGhTdKVHPQx1Vj7yYVTAiyLMsWsLUAoMf0m6dT6msTs0SdrXHRbjzXavVXxRj/wZZJA==",
+            "dependencies": {
+                "@antv/color-util": "^2.0.1",
+                "@antv/util": "~2.0.0",
+                "tslib": "^1.10.0"
+            }
+        },
+        "node_modules/@antv/attr/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@antv/color-util": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@antv/color-util/-/color-util-2.0.6.tgz",
+            "integrity": "sha512-KnPEaAH+XNJMjax9U35W67nzPI+QQ2x27pYlzmSIWrbj4/k8PGrARXfzDTjwoozHJY8qG62Z+Ww6Alhu2FctXQ==",
+            "dependencies": {
+                "@antv/util": "^2.0.9",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/component": {
+            "version": "0.8.28",
+            "resolved": "https://registry.npmjs.org/@antv/component/-/component-0.8.28.tgz",
+            "integrity": "sha512-SlmTBl9mWFnUQclylKhTlCnB0bkLI3yH5TlC37hdSIq1sFqG4RD5CmVFcFx5lb6itKe4ZtPl4oboVxjtatkwvw==",
+            "dependencies": {
+                "@antv/color-util": "^2.0.3",
+                "@antv/dom-util": "~2.0.1",
+                "@antv/g-base": "^0.5.9",
+                "@antv/matrix-util": "^3.1.0-beta.1",
+                "@antv/path-util": "~2.0.7",
+                "@antv/scale": "~0.3.1",
+                "@antv/util": "~2.0.0",
+                "fecha": "~4.2.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/coord": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@antv/coord/-/coord-0.3.1.tgz",
+            "integrity": "sha512-rFE94C8Xzbx4xmZnHh2AnlB3Qm1n5x0VT3OROy257IH6Rm4cuzv1+tZaUBATviwZd99S+rOY9telw/+6C9GbRw==",
+            "dependencies": {
+                "@antv/matrix-util": "^3.1.0-beta.2",
+                "@antv/util": "~2.0.12",
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@antv/dom-util": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@antv/dom-util/-/dom-util-2.0.4.tgz",
+            "integrity": "sha512-2shXUl504fKwt82T3GkuT4Uoc6p9qjCKnJ8gXGLSW4T1W37dqf9AV28aCfoVPHp2BUXpSsB+PAJX2rG/jLHsLQ==",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/event-emitter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@antv/event-emitter/-/event-emitter-0.1.3.tgz",
+            "integrity": "sha512-4ddpsiHN9Pd4UIlWuKVK1C4IiZIdbwQvy9i7DUSI3xNJ89FPUFt8lxDYj8GzzfdllV0NkJTRxnG+FvLk0llidg=="
+        },
+        "node_modules/@antv/g-base": {
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@antv/g-base/-/g-base-0.5.11.tgz",
+            "integrity": "sha512-10Hkq7XksVCqxZZrPkd6HTU9tb/+2meCVEMy/edhS4I/sokhcgC9m3fQP5bE8rA3EVKwELE7MJHZ98BEpVFqvQ==",
+            "dependencies": {
+                "@antv/event-emitter": "^0.1.1",
+                "@antv/g-math": "^0.1.6",
+                "@antv/matrix-util": "^3.1.0-beta.1",
+                "@antv/path-util": "~2.0.5",
+                "@antv/util": "~2.0.13",
+                "@types/d3-timer": "^2.0.0",
+                "d3-ease": "^1.0.5",
+                "d3-interpolate": "^1.3.2",
+                "d3-timer": "^1.0.9",
+                "detect-browser": "^5.1.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/g-canvas": {
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/@antv/g-canvas/-/g-canvas-0.5.12.tgz",
+            "integrity": "sha512-iJ/muwwqCCNONVlPIzv/7OL5iLguaKRj2BxNMytUO3TWwamM+kHkiyYEOkS0dPn9h/hBsHYlLUluSVz2Fp6/bw==",
+            "dependencies": {
+                "@antv/g-base": "^0.5.3",
+                "@antv/g-math": "^0.1.6",
+                "@antv/matrix-util": "^3.1.0-beta.1",
+                "@antv/path-util": "~2.0.5",
+                "@antv/util": "~2.0.0",
+                "gl-matrix": "^3.0.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/g-math": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@antv/g-math/-/g-math-0.1.7.tgz",
+            "integrity": "sha512-xGyXaloD1ynfp7gS4VuV+MjSptZIwHvLHr8ekXJSFAeWPYLu84yOW2wOZHDdp1bzDAIuRv6xDBW58YGHrWsFcA==",
+            "dependencies": {
+                "@antv/util": "~2.0.0",
+                "gl-matrix": "^3.0.0"
+            }
+        },
+        "node_modules/@antv/g-svg": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/@antv/g-svg/-/g-svg-0.5.6.tgz",
+            "integrity": "sha512-Xve1EUGk4HMbl2nq4ozR4QLh6GyoZ8Xw/+9kHYI4B5P2lIUQU95MuRsaLFfW5NNpZDx85ZeH97tqEmC9L96E7A==",
+            "dependencies": {
+                "@antv/g-base": "^0.5.3",
+                "@antv/g-math": "^0.1.6",
+                "@antv/util": "~2.0.0",
+                "detect-browser": "^5.0.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/g2": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-4.2.6.tgz",
+            "integrity": "sha512-mg3r+U9GqOU4aqosSUll5srEgOZxgl8WZ5Z6+9gH0ewaUGusvy2MUm6vEMyrp+VBoU0R/fOGv/3EuqRhT7+cgg==",
+            "dependencies": {
+                "@antv/adjust": "^0.2.1",
+                "@antv/attr": "^0.3.1",
+                "@antv/color-util": "^2.0.2",
+                "@antv/component": "^0.8.27",
+                "@antv/coord": "^0.3.0",
+                "@antv/dom-util": "^2.0.2",
+                "@antv/event-emitter": "~0.1.0",
+                "@antv/g-base": "~0.5.6",
+                "@antv/g-canvas": "~0.5.10",
+                "@antv/g-svg": "~0.5.6",
+                "@antv/matrix-util": "^3.1.0-beta.3",
+                "@antv/path-util": "^2.0.15",
+                "@antv/scale": "^0.3.14",
+                "@antv/util": "~2.0.5",
+                "tslib": "^2.0.0"
+            }
+        },
+        "node_modules/@antv/g2plot": {
+            "version": "2.4.20",
+            "resolved": "https://registry.npmjs.org/@antv/g2plot/-/g2plot-2.4.20.tgz",
+            "integrity": "sha512-MHFTe3zdEHy/5VHdG9LmX9jQy9NdZm31olQjhE65eGpxhX5N1ibyo+qO247I9Jazb4sLD5LNWYPtPHofUOUaNg==",
+            "dependencies": {
+                "@antv/event-emitter": "^0.1.2",
+                "@antv/g2": "^4.1.26",
+                "@antv/util": "^2.0.17",
+                "d3-hierarchy": "^2.0.0",
+                "d3-regression": "^1.3.5",
+                "fmin": "^0.0.2",
+                "pdfast": "^0.2.0",
+                "size-sensor": "^1.0.1",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/matrix-util": {
+            "version": "3.1.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@antv/matrix-util/-/matrix-util-3.1.0-beta.3.tgz",
+            "integrity": "sha512-W2R6Za3A6CmG51Y/4jZUM/tFgYSq7vTqJL1VD9dKrvwxS4sE0ZcXINtkp55CdyBwJ6Cwm8pfoRpnD4FnHahN0A==",
+            "dependencies": {
+                "@antv/util": "^2.0.9",
+                "gl-matrix": "^3.4.3",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/path-util": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/@antv/path-util/-/path-util-2.0.15.tgz",
+            "integrity": "sha512-R2VLZ5C8PLPtr3VciNyxtjKqJ0XlANzpFb5sE9GE61UQqSRuSVSzIakMxjEPrpqbgc+s+y8i+fmc89Snu7qbNw==",
+            "dependencies": {
+                "@antv/matrix-util": "^3.0.4",
+                "@antv/util": "^2.0.9",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/path-util/node_modules/@antv/matrix-util": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@antv/matrix-util/-/matrix-util-3.0.4.tgz",
+            "integrity": "sha512-BAPyu6dUliHcQ7fm9hZSGKqkwcjEDVLVAstlHULLvcMZvANHeLXgHEgV7JqcAV/GIhIz8aZChIlzM1ZboiXpYQ==",
+            "dependencies": {
+                "@antv/util": "^2.0.9",
+                "gl-matrix": "^3.3.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/@antv/scale": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.3.18.tgz",
+            "integrity": "sha512-GHwE6Lo7S/Q5fgaLPaCsW+CH+3zl4aXpnN1skOiEY0Ue9/u+s2EySv6aDXYkAqs//i0uilMDD/0/4n8caX9U9w==",
+            "dependencies": {
+                "@antv/util": "~2.0.3",
+                "fecha": "~4.2.0",
+                "tslib": "^2.0.0"
+            }
+        },
+        "node_modules/@antv/util": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@antv/util/-/util-2.0.17.tgz",
+            "integrity": "sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==",
+            "dependencies": {
+                "csstype": "^3.0.8",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/@apollo/client": {
@@ -3183,7 +3415,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
             "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.18.6"
             },
@@ -3198,7 +3429,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
             "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
-            "peer": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.18.6"
             },
@@ -3723,6 +3953,22 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+            "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@eslint/eslintrc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -4005,6 +4251,36 @@
             "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
             "dev": true,
             "optional": true
+        },
+        "node_modules/@playwright/experimental-ct-react": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.25.0.tgz",
+            "integrity": "sha512-tF6i6L4NqcKyRwv/zf3WohDifEE65T7VAMmmEGTwHpMImT1p8r/3r6KpRf+7vJ2Kqzo16QTNoShX068Nas7x/w==",
+            "dev": true,
+            "dependencies": {
+                "@playwright/test": "1.25.0",
+                "@vitejs/plugin-react": "^1.0.7",
+                "vite": "^2.9.5"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.0.tgz",
+            "integrity": "sha512-j4EZhTTQI3dBeWblE21EV//swwmBtOpIrLdOIJIRv4uqsLdHgBg1z+JtTg+AeC5o2bAXIE26kDNW5A0TimG8Bg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "playwright-core": "1.25.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@react-native-community/cli-clean": {
             "version": "8.0.0",
@@ -5373,6 +5649,19 @@
             "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
             "peer": true
         },
+        "node_modules/@rollup/pluginutils": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+            "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+            "dev": true,
+            "dependencies": {
+                "estree-walker": "^2.0.1",
+                "picomatch": "^2.2.2"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
+        },
         "node_modules/@sideway/address": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -5657,6 +5946,11 @@
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
             "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
         },
+        "node_modules/@types/d3-timer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.1.tgz",
+            "integrity": "sha512-TF8aoF5cHcLO7W7403blM7L1T+6NF3XMyN3fxyUolq2uOcFeicG/khQg/dGxiCJWoAcmYulYN7LYSRKO54IXaA=="
+        },
         "node_modules/@types/eslint": {
             "version": "8.4.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.2.tgz",
@@ -5900,6 +6194,34 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "peer": true
+        },
+        "node_modules/@vitejs/plugin-react": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz",
+            "integrity": "sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "^7.17.10",
+                "@babel/plugin-transform-react-jsx": "^7.17.3",
+                "@babel/plugin-transform-react-jsx-development": "^7.16.7",
+                "@babel/plugin-transform-react-jsx-self": "^7.16.7",
+                "@babel/plugin-transform-react-jsx-source": "^7.16.7",
+                "@rollup/pluginutils": "^4.2.1",
+                "react-refresh": "^0.13.0",
+                "resolve": "^1.22.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/@vitejs/plugin-react/node_modules/react-refresh": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+            "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -6221,6 +6543,30 @@
                 }
             }
         },
+        "node_modules/align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+            "dependencies": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/align-text/node_modules/kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+            "dependencies": {
+                "is-buffer": "^1.1.5"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/amazon-cognito-identity-js": {
             "version": "5.2.10",
             "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.10.tgz",
@@ -6231,6 +6577,14 @@
                 "fast-base64-decode": "^1.0.0",
                 "isomorphic-unfetch": "^3.0.0",
                 "js-cookie": "^2.2.1"
+            }
+        },
+        "node_modules/amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
+            "engines": {
+                "node": ">=0.4.2"
             }
         },
         "node_modules/anser": {
@@ -7136,6 +7490,18 @@
                 }
             ]
         },
+        "node_modules/center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+            "dependencies": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -7591,6 +7957,11 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/contour_plot": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/contour_plot/-/contour_plot-0.0.1.tgz",
+            "integrity": "sha512-Nil2HI76Xux6sVGORvhSS8v66m+/h5CwFkBJDO+U5vWaMdNC0yXNCsGDPbzPhvqOEU5koebhdEvD372LI+IyLw=="
+        },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -7847,8 +8218,40 @@
         "node_modules/csstype": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-            "dev": true
+            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        },
+        "node_modules/d3-color": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+            "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "node_modules/d3-ease": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+            "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "node_modules/d3-hierarchy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+            "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+        },
+        "node_modules/d3-interpolate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+            "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+            "dependencies": {
+                "d3-color": "1"
+            }
+        },
+        "node_modules/d3-regression": {
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
+            "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw=="
+        },
+        "node_modules/d3-timer": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+            "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -7893,7 +8296,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7904,6 +8306,22 @@
             "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
             "engines": {
                 "node": ">=0.10"
+            }
+        },
+        "node_modules/deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "dependencies": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/deep-is": {
@@ -7980,6 +8398,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+        },
         "node_modules/denodeify": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
@@ -8002,6 +8425,11 @@
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
             }
+        },
+        "node_modules/detect-browser": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+            "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
         },
         "node_modules/detect-node": {
             "version": "2.1.0",
@@ -8167,6 +8595,17 @@
                 "webpack": "^4 || ^5"
             }
         },
+        "node_modules/dotignore": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+            "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+            "dependencies": {
+                "minimatch": "^3.0.4"
+            },
+            "bin": {
+                "ignored": "bin/ignored"
+            }
+        },
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8277,7 +8716,6 @@
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
             "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -8329,7 +8767,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "dev": true,
             "dependencies": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
@@ -8340,6 +8777,362 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/esbuild": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+            "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/linux-loong64": "0.14.54",
+                "esbuild-android-64": "0.14.54",
+                "esbuild-android-arm64": "0.14.54",
+                "esbuild-darwin-64": "0.14.54",
+                "esbuild-darwin-arm64": "0.14.54",
+                "esbuild-freebsd-64": "0.14.54",
+                "esbuild-freebsd-arm64": "0.14.54",
+                "esbuild-linux-32": "0.14.54",
+                "esbuild-linux-64": "0.14.54",
+                "esbuild-linux-arm": "0.14.54",
+                "esbuild-linux-arm64": "0.14.54",
+                "esbuild-linux-mips64le": "0.14.54",
+                "esbuild-linux-ppc64le": "0.14.54",
+                "esbuild-linux-riscv64": "0.14.54",
+                "esbuild-linux-s390x": "0.14.54",
+                "esbuild-netbsd-64": "0.14.54",
+                "esbuild-openbsd-64": "0.14.54",
+                "esbuild-sunos-64": "0.14.54",
+                "esbuild-windows-32": "0.14.54",
+                "esbuild-windows-64": "0.14.54",
+                "esbuild-windows-arm64": "0.14.54"
+            }
+        },
+        "node_modules/esbuild-android-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+            "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+            "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+            "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+            "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+            "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+            "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+            "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+            "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+            "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+            "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+            "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+            "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+            "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+            "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+            "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+            "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+            "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+            "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+            "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+            "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/escalade": {
@@ -8836,6 +9629,12 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9240,6 +10039,11 @@
                 "bser": "2.1.1"
             }
         },
+        "node_modules/fecha": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9371,6 +10175,18 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/fmin": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/fmin/-/fmin-0.0.2.tgz",
+            "integrity": "sha512-sSi6DzInhl9d8yqssDfGZejChO8d2bAGIpysPsvYsxFe898z89XhCZg6CPNV3nhUhFefeC/AXZK2bAJxlBjN6A==",
+            "dependencies": {
+                "contour_plot": "^0.0.1",
+                "json2module": "^0.0.3",
+                "rollup": "^0.25.8",
+                "tape": "^4.5.1",
+                "uglify-js": "^2.6.2"
+            }
+        },
         "node_modules/follow-redirects": {
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
@@ -9389,6 +10205,14 @@
                 "debug": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dependencies": {
+                "is-callable": "^1.1.3"
             }
         },
         "node_modules/for-in": {
@@ -9482,7 +10306,6 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
             "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -9507,7 +10330,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9558,7 +10380,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
             "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
@@ -9578,6 +10399,11 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/gl-matrix": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+            "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -9674,11 +10500,29 @@
                 "node": ">= 0.4.0"
             }
         },
+        "node_modules/has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/has-ansi/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
             "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -9717,7 +10561,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
             "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.2"
             },
@@ -10205,7 +11048,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
             "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-            "dev": true,
             "dependencies": {
                 "get-intrinsic": "^1.1.0",
                 "has": "^1.0.3",
@@ -10260,6 +11102,21 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -10270,7 +11127,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
             "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-            "dev": true,
             "dependencies": {
                 "has-bigints": "^1.0.1"
             },
@@ -10294,7 +11150,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
             "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -10309,14 +11164,12 @@
         "node_modules/is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "peer": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "node_modules/is-callable": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
             "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10351,7 +11204,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
             "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "dev": true,
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -10455,7 +11307,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
             "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -10475,7 +11326,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
             "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-            "dev": true,
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -10513,7 +11363,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -10529,7 +11378,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
             "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2"
             },
@@ -10553,7 +11401,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-            "dev": true,
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -10568,7 +11415,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
             "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.2"
             },
@@ -10595,7 +11441,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2"
             },
@@ -11491,6 +12336,17 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/json2module": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/json2module/-/json2module-0.0.3.tgz",
+            "integrity": "sha512-qYGxqrRrt4GbB8IEOy1jJGypkNsjWoIMlZt4bAsmUScCA507Hbc2p1JOhBzqn45u3PWafUgH2OnzyNU7udO/GA==",
+            "dependencies": {
+                "rw": "^1.3.2"
+            },
+            "bin": {
+                "json2module": "bin/json2module"
+            }
+        },
         "node_modules/json2mq": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
@@ -11571,6 +12427,14 @@
             "dev": true,
             "dependencies": {
                 "language-subtag-registry": "~0.3.2"
+            }
+        },
+        "node_modules/lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/leven": {
@@ -11751,6 +12615,14 @@
             },
             "bin": {
                 "logkitty": "bin/logkitty.js"
+            }
+        },
+        "node_modules/longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg==",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/loose-envify": {
@@ -12505,8 +13377,7 @@
         "node_modules/minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-            "peer": true
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "node_modules/mixin-deep": {
             "version": "1.3.2",
@@ -12852,7 +13723,21 @@
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
             "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -13314,6 +14199,11 @@
             "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
             "dev": true
         },
+        "node_modules/pdfast": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/pdfast/-/pdfast-0.2.0.tgz",
+            "integrity": "sha512-cq6TTu6qKSFUHwEahi68k/kqN2mfepjkGrG9Un70cgdRRKLKY6Rf8P8uvP2NvZktaQZNF3YE7agEkLj0vGK9bA=="
+        },
         "node_modules/picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -13357,6 +14247,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.0.tgz",
+            "integrity": "sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==",
+            "dev": true,
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
             }
         },
         "node_modules/plist": {
@@ -14299,6 +15201,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-content-loader": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-5.1.4.tgz",
+            "integrity": "sha512-hTq7pZi2GKCK6a9d3u6XStozm0QGCEjw8cSqQReiWnh2up6IwCha5R5TF0o6SY5qUDpByloEZEZtnFxpJyENFw==",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": ">=16.0.0"
+            }
+        },
         "node_modules/react-devtools-core": {
             "version": "4.24.0",
             "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
@@ -14515,7 +15428,6 @@
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
             "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -14616,7 +15528,6 @@
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-            "peer": true,
             "engines": {
                 "node": ">=0.10"
             }
@@ -14712,6 +15623,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/resumer": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+            "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+            "dependencies": {
+                "through": "~2.3.4"
+            }
+        },
         "node_modules/ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -14730,6 +15649,17 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+            "dependencies": {
+                "align-text": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -14744,6 +15674,93 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/rollup": {
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.25.8.tgz",
+            "integrity": "sha512-a2S4Bh3bgrdO4BhKr2E4nZkjTvrJ2m2bWjMTzVYtoqSCn0HnuxosXnaJUHrMEziOWr3CzL9GjilQQKcyCQpJoA==",
+            "dependencies": {
+                "chalk": "^1.1.1",
+                "minimist": "^1.2.0",
+                "source-map-support": "^0.3.2"
+            },
+            "bin": {
+                "rollup": "bin/rollup"
+            }
+        },
+        "node_modules/rollup/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup/node_modules/ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup/node_modules/chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+            "dependencies": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup/node_modules/source-map": {
+            "version": "0.1.32",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+            "integrity": "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==",
+            "dependencies": {
+                "amdefine": ">=0.0.4"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/rollup/node_modules/source-map-support": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+            "integrity": "sha512-9O4+y9n64RewmFoKUZ/5Tx9IHIcXM6Q+RTSw6ehnqybUz4a7iwR3Eaw80uLtqqQ5D0C+5H03D4KKGo9PdP33Gg==",
+            "dependencies": {
+                "source-map": "0.1.32"
+            }
+        },
+        "node_modules/rollup/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/rollup/node_modules/supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/rw": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
         },
         "node_modules/rxjs": {
             "version": "7.5.5",
@@ -15109,7 +16126,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
             "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.0",
                 "get-intrinsic": "^1.0.2",
@@ -15129,6 +16145,11 @@
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "peer": true
+        },
+        "node_modules/size-sensor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.1.tgz",
+            "integrity": "sha512-QTy7MnuugCFXIedXRpUSk9gUnyNiaxIdxGfUjr8xxXOqIB3QvBUYP9+b51oCg2C4dnhaeNk/h57TxjbvoJrJUA=="
         },
         "node_modules/slash": {
             "version": "2.0.0",
@@ -15678,11 +16699,26 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
+            "integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
             "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
@@ -15696,7 +16732,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
             "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
@@ -15819,6 +16854,31 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/tape": {
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-4.15.1.tgz",
+            "integrity": "sha512-k7F5pyr91n9D/yjSJwbLLYDCrTWXxMSXbbmHX2n334lSIc2rxeXyFkaBv4UuUd2gBYMrAOalPutAiCxC6q1qbw==",
+            "dependencies": {
+                "call-bind": "~1.0.2",
+                "deep-equal": "~1.1.1",
+                "defined": "~1.0.0",
+                "dotignore": "~0.1.2",
+                "for-each": "~0.3.3",
+                "glob": "~7.2.0",
+                "has": "~1.0.3",
+                "inherits": "~2.0.4",
+                "is-regex": "~1.1.4",
+                "minimist": "~1.2.6",
+                "object-inspect": "~1.12.0",
+                "resolve": "~1.22.0",
+                "resumer": "~0.0.0",
+                "string.prototype.trim": "~1.2.5",
+                "through": "~2.3.8"
+            },
+            "bin": {
+                "tape": "bin/tape"
             }
         },
         "node_modules/temp": {
@@ -15964,6 +17024,11 @@
             "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
             "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
             "peer": true
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
         "node_modules/through2": {
             "version": "2.0.5",
@@ -16283,11 +17348,71 @@
             "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
             "peer": true
         },
+        "node_modules/uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+            "dependencies": {
+                "source-map": "~0.5.1",
+                "yargs": "~3.10.0"
+            },
+            "bin": {
+                "uglifyjs": "bin/uglifyjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            },
+            "optionalDependencies": {
+                "uglify-to-browserify": "~1.0.0"
+            }
+        },
+        "node_modules/uglify-js/node_modules/camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/uglify-js/node_modules/cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+            "dependencies": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+            }
+        },
+        "node_modules/uglify-js/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/uglify-js/node_modules/yargs": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+            "dependencies": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+            }
+        },
+        "node_modules/uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+            "optional": true
+        },
         "node_modules/unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
             "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-bigints": "^1.0.2",
@@ -16533,6 +17658,58 @@
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/vite": {
+            "version": "2.9.15",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+            "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "^0.14.27",
+                "postcss": "^8.4.13",
+                "resolve": "^1.22.0",
+                "rollup": ">=2.59.0 <2.78.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": ">=12.2.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            },
+            "peerDependencies": {
+                "less": "*",
+                "sass": "*",
+                "stylus": "*"
+            },
+            "peerDependenciesMeta": {
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite/node_modules/rollup": {
+            "version": "2.77.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+            "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+            "dev": true,
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
             }
         },
         "node_modules/vlq": {
@@ -16948,7 +18125,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "dev": true,
             "dependencies": {
                 "is-bigint": "^1.0.1",
                 "is-boolean-object": "^1.1.0",
@@ -16972,6 +18148,14 @@
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
         },
+        "node_modules/window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
         "node_modules/word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -16980,6 +18164,14 @@
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wordwrap": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+            "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
+            "engines": {
+                "node": ">=0.4.0"
             }
         },
         "node_modules/wrap-ansi": {
@@ -17180,6 +18372,15 @@
             "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.2.1.tgz",
             "integrity": "sha512-EB0iwlKDGpG93hW8f85CTJTs4SvMX7tt5ceupvhALp1IF44SeUFOMhKUOYqpsoYWQKAOuTRDMqn75rEaKDp0Xw=="
         },
+        "@ant-design/plots": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@ant-design/plots/-/plots-1.2.1.tgz",
+            "integrity": "sha512-wbcmhHRkVi7IFyqzVNUozcJtIpgWHOFHbny5T+DLQoE2lzh+A1nTOfhlPJXc6aq56uIg6w+4iN/umsJKUmcLPw==",
+            "requires": {
+                "@antv/g2plot": "^2.2.11",
+                "react-content-loader": "^5.0.4"
+            }
+        },
         "@ant-design/react-slick": {
             "version": "0.29.2",
             "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-0.29.2.tgz",
@@ -17190,6 +18391,229 @@
                 "json2mq": "^0.2.0",
                 "lodash": "^4.17.21",
                 "resize-observer-polyfill": "^1.5.1"
+            }
+        },
+        "@antv/adjust": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@antv/adjust/-/adjust-0.2.5.tgz",
+            "integrity": "sha512-MfWZOkD9CqXRES6MBGRNe27Q577a72EIwyMnE29wIlPliFvJfWwsrONddpGU7lilMpVKecS3WAzOoip3RfPTRQ==",
+            "requires": {
+                "@antv/util": "~2.0.0",
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@antv/attr": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@antv/attr/-/attr-0.3.3.tgz",
+            "integrity": "sha512-7iSSRhYzZ7pYXZKTL1ECGhTdKVHPQx1Vj7yYVTAiyLMsWsLUAoMf0m6dT6msTs0SdrXHRbjzXavVXxRj/wZZJA==",
+            "requires": {
+                "@antv/color-util": "^2.0.1",
+                "@antv/util": "~2.0.0",
+                "tslib": "^1.10.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@antv/color-util": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@antv/color-util/-/color-util-2.0.6.tgz",
+            "integrity": "sha512-KnPEaAH+XNJMjax9U35W67nzPI+QQ2x27pYlzmSIWrbj4/k8PGrARXfzDTjwoozHJY8qG62Z+Ww6Alhu2FctXQ==",
+            "requires": {
+                "@antv/util": "^2.0.9",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/component": {
+            "version": "0.8.28",
+            "resolved": "https://registry.npmjs.org/@antv/component/-/component-0.8.28.tgz",
+            "integrity": "sha512-SlmTBl9mWFnUQclylKhTlCnB0bkLI3yH5TlC37hdSIq1sFqG4RD5CmVFcFx5lb6itKe4ZtPl4oboVxjtatkwvw==",
+            "requires": {
+                "@antv/color-util": "^2.0.3",
+                "@antv/dom-util": "~2.0.1",
+                "@antv/g-base": "^0.5.9",
+                "@antv/matrix-util": "^3.1.0-beta.1",
+                "@antv/path-util": "~2.0.7",
+                "@antv/scale": "~0.3.1",
+                "@antv/util": "~2.0.0",
+                "fecha": "~4.2.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/coord": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@antv/coord/-/coord-0.3.1.tgz",
+            "integrity": "sha512-rFE94C8Xzbx4xmZnHh2AnlB3Qm1n5x0VT3OROy257IH6Rm4cuzv1+tZaUBATviwZd99S+rOY9telw/+6C9GbRw==",
+            "requires": {
+                "@antv/matrix-util": "^3.1.0-beta.2",
+                "@antv/util": "~2.0.12",
+                "tslib": "^2.1.0"
+            }
+        },
+        "@antv/dom-util": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@antv/dom-util/-/dom-util-2.0.4.tgz",
+            "integrity": "sha512-2shXUl504fKwt82T3GkuT4Uoc6p9qjCKnJ8gXGLSW4T1W37dqf9AV28aCfoVPHp2BUXpSsB+PAJX2rG/jLHsLQ==",
+            "requires": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/event-emitter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@antv/event-emitter/-/event-emitter-0.1.3.tgz",
+            "integrity": "sha512-4ddpsiHN9Pd4UIlWuKVK1C4IiZIdbwQvy9i7DUSI3xNJ89FPUFt8lxDYj8GzzfdllV0NkJTRxnG+FvLk0llidg=="
+        },
+        "@antv/g-base": {
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@antv/g-base/-/g-base-0.5.11.tgz",
+            "integrity": "sha512-10Hkq7XksVCqxZZrPkd6HTU9tb/+2meCVEMy/edhS4I/sokhcgC9m3fQP5bE8rA3EVKwELE7MJHZ98BEpVFqvQ==",
+            "requires": {
+                "@antv/event-emitter": "^0.1.1",
+                "@antv/g-math": "^0.1.6",
+                "@antv/matrix-util": "^3.1.0-beta.1",
+                "@antv/path-util": "~2.0.5",
+                "@antv/util": "~2.0.13",
+                "@types/d3-timer": "^2.0.0",
+                "d3-ease": "^1.0.5",
+                "d3-interpolate": "^1.3.2",
+                "d3-timer": "^1.0.9",
+                "detect-browser": "^5.1.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/g-canvas": {
+            "version": "0.5.12",
+            "resolved": "https://registry.npmjs.org/@antv/g-canvas/-/g-canvas-0.5.12.tgz",
+            "integrity": "sha512-iJ/muwwqCCNONVlPIzv/7OL5iLguaKRj2BxNMytUO3TWwamM+kHkiyYEOkS0dPn9h/hBsHYlLUluSVz2Fp6/bw==",
+            "requires": {
+                "@antv/g-base": "^0.5.3",
+                "@antv/g-math": "^0.1.6",
+                "@antv/matrix-util": "^3.1.0-beta.1",
+                "@antv/path-util": "~2.0.5",
+                "@antv/util": "~2.0.0",
+                "gl-matrix": "^3.0.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/g-math": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/@antv/g-math/-/g-math-0.1.7.tgz",
+            "integrity": "sha512-xGyXaloD1ynfp7gS4VuV+MjSptZIwHvLHr8ekXJSFAeWPYLu84yOW2wOZHDdp1bzDAIuRv6xDBW58YGHrWsFcA==",
+            "requires": {
+                "@antv/util": "~2.0.0",
+                "gl-matrix": "^3.0.0"
+            }
+        },
+        "@antv/g-svg": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/@antv/g-svg/-/g-svg-0.5.6.tgz",
+            "integrity": "sha512-Xve1EUGk4HMbl2nq4ozR4QLh6GyoZ8Xw/+9kHYI4B5P2lIUQU95MuRsaLFfW5NNpZDx85ZeH97tqEmC9L96E7A==",
+            "requires": {
+                "@antv/g-base": "^0.5.3",
+                "@antv/g-math": "^0.1.6",
+                "@antv/util": "~2.0.0",
+                "detect-browser": "^5.0.0",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/g2": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-4.2.6.tgz",
+            "integrity": "sha512-mg3r+U9GqOU4aqosSUll5srEgOZxgl8WZ5Z6+9gH0ewaUGusvy2MUm6vEMyrp+VBoU0R/fOGv/3EuqRhT7+cgg==",
+            "requires": {
+                "@antv/adjust": "^0.2.1",
+                "@antv/attr": "^0.3.1",
+                "@antv/color-util": "^2.0.2",
+                "@antv/component": "^0.8.27",
+                "@antv/coord": "^0.3.0",
+                "@antv/dom-util": "^2.0.2",
+                "@antv/event-emitter": "~0.1.0",
+                "@antv/g-base": "~0.5.6",
+                "@antv/g-canvas": "~0.5.10",
+                "@antv/g-svg": "~0.5.6",
+                "@antv/matrix-util": "^3.1.0-beta.3",
+                "@antv/path-util": "^2.0.15",
+                "@antv/scale": "^0.3.14",
+                "@antv/util": "~2.0.5",
+                "tslib": "^2.0.0"
+            }
+        },
+        "@antv/g2plot": {
+            "version": "2.4.20",
+            "resolved": "https://registry.npmjs.org/@antv/g2plot/-/g2plot-2.4.20.tgz",
+            "integrity": "sha512-MHFTe3zdEHy/5VHdG9LmX9jQy9NdZm31olQjhE65eGpxhX5N1ibyo+qO247I9Jazb4sLD5LNWYPtPHofUOUaNg==",
+            "requires": {
+                "@antv/event-emitter": "^0.1.2",
+                "@antv/g2": "^4.1.26",
+                "@antv/util": "^2.0.17",
+                "d3-hierarchy": "^2.0.0",
+                "d3-regression": "^1.3.5",
+                "fmin": "^0.0.2",
+                "pdfast": "^0.2.0",
+                "size-sensor": "^1.0.1",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/matrix-util": {
+            "version": "3.1.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@antv/matrix-util/-/matrix-util-3.1.0-beta.3.tgz",
+            "integrity": "sha512-W2R6Za3A6CmG51Y/4jZUM/tFgYSq7vTqJL1VD9dKrvwxS4sE0ZcXINtkp55CdyBwJ6Cwm8pfoRpnD4FnHahN0A==",
+            "requires": {
+                "@antv/util": "^2.0.9",
+                "gl-matrix": "^3.4.3",
+                "tslib": "^2.0.3"
+            }
+        },
+        "@antv/path-util": {
+            "version": "2.0.15",
+            "resolved": "https://registry.npmjs.org/@antv/path-util/-/path-util-2.0.15.tgz",
+            "integrity": "sha512-R2VLZ5C8PLPtr3VciNyxtjKqJ0XlANzpFb5sE9GE61UQqSRuSVSzIakMxjEPrpqbgc+s+y8i+fmc89Snu7qbNw==",
+            "requires": {
+                "@antv/matrix-util": "^3.0.4",
+                "@antv/util": "^2.0.9",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "@antv/matrix-util": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/@antv/matrix-util/-/matrix-util-3.0.4.tgz",
+                    "integrity": "sha512-BAPyu6dUliHcQ7fm9hZSGKqkwcjEDVLVAstlHULLvcMZvANHeLXgHEgV7JqcAV/GIhIz8aZChIlzM1ZboiXpYQ==",
+                    "requires": {
+                        "@antv/util": "^2.0.9",
+                        "gl-matrix": "^3.3.0",
+                        "tslib": "^2.0.3"
+                    }
+                }
+            }
+        },
+        "@antv/scale": {
+            "version": "0.3.18",
+            "resolved": "https://registry.npmjs.org/@antv/scale/-/scale-0.3.18.tgz",
+            "integrity": "sha512-GHwE6Lo7S/Q5fgaLPaCsW+CH+3zl4aXpnN1skOiEY0Ue9/u+s2EySv6aDXYkAqs//i0uilMDD/0/4n8caX9U9w==",
+            "requires": {
+                "@antv/util": "~2.0.3",
+                "fecha": "~4.2.0",
+                "tslib": "^2.0.0"
+            }
+        },
+        "@antv/util": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@antv/util/-/util-2.0.17.tgz",
+            "integrity": "sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==",
+            "requires": {
+                "csstype": "^3.0.8",
+                "tslib": "^2.0.3"
             }
         },
         "@apollo/client": {
@@ -19566,7 +20990,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.18.6.tgz",
             "integrity": "sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==",
-            "peer": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.18.6"
             }
@@ -19575,7 +20998,6 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.18.6.tgz",
             "integrity": "sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==",
-            "peer": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.18.6"
             }
@@ -19952,6 +21374,13 @@
             "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
             "dev": true
         },
+        "@esbuild/linux-loong64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+            "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+            "dev": true,
+            "optional": true
+        },
         "@eslint/eslintrc": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
@@ -20183,6 +21612,27 @@
             "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
             "dev": true,
             "optional": true
+        },
+        "@playwright/experimental-ct-react": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.25.0.tgz",
+            "integrity": "sha512-tF6i6L4NqcKyRwv/zf3WohDifEE65T7VAMmmEGTwHpMImT1p8r/3r6KpRf+7vJ2Kqzo16QTNoShX068Nas7x/w==",
+            "dev": true,
+            "requires": {
+                "@playwright/test": "1.25.0",
+                "@vitejs/plugin-react": "^1.0.7",
+                "vite": "^2.9.5"
+            }
+        },
+        "@playwright/test": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.25.0.tgz",
+            "integrity": "sha512-j4EZhTTQI3dBeWblE21EV//swwmBtOpIrLdOIJIRv4uqsLdHgBg1z+JtTg+AeC5o2bAXIE26kDNW5A0TimG8Bg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "playwright-core": "1.25.0"
+            }
         },
         "@react-native-community/cli-clean": {
             "version": "8.0.0",
@@ -21237,6 +22687,16 @@
             "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==",
             "peer": true
         },
+        "@rollup/pluginutils": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
+            "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+            "dev": true,
+            "requires": {
+                "estree-walker": "^2.0.1",
+                "picomatch": "^2.2.2"
+            }
+        },
         "@sideway/address": {
             "version": "4.1.4",
             "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -21464,6 +22924,11 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
             "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+        },
+        "@types/d3-timer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-2.0.1.tgz",
+            "integrity": "sha512-TF8aoF5cHcLO7W7403blM7L1T+6NF3XMyN3fxyUolq2uOcFeicG/khQg/dGxiCJWoAcmYulYN7LYSRKO54IXaA=="
         },
         "@types/eslint": {
             "version": "8.4.2",
@@ -21708,6 +23173,30 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
             "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
             "peer": true
+        },
+        "@vitejs/plugin-react": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz",
+            "integrity": "sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.17.10",
+                "@babel/plugin-transform-react-jsx": "^7.17.3",
+                "@babel/plugin-transform-react-jsx-development": "^7.16.7",
+                "@babel/plugin-transform-react-jsx-self": "^7.16.7",
+                "@babel/plugin-transform-react-jsx-source": "^7.16.7",
+                "@rollup/pluginutils": "^4.2.1",
+                "react-refresh": "^0.13.0",
+                "resolve": "^1.22.0"
+            },
+            "dependencies": {
+                "react-refresh": {
+                    "version": "0.13.0",
+                    "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
+                    "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+                    "dev": true
+                }
+            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -21979,6 +23468,26 @@
                 "ajv": "^8.0.0"
             }
         },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+            "requires": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
         "amazon-cognito-identity-js": {
             "version": "5.2.10",
             "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.10.tgz",
@@ -21990,6 +23499,11 @@
                 "isomorphic-unfetch": "^3.0.0",
                 "js-cookie": "^2.2.1"
             }
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg=="
         },
         "anser": {
             "version": "1.4.10",
@@ -22705,6 +24219,15 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
             "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g=="
         },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+            "requires": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+            }
+        },
         "chalk": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -23066,6 +24589,11 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
         },
+        "contour_plot": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/contour_plot/-/contour_plot-0.0.1.tgz",
+            "integrity": "sha512-Nil2HI76Xux6sVGORvhSS8v66m+/h5CwFkBJDO+U5vWaMdNC0yXNCsGDPbzPhvqOEU5koebhdEvD372LI+IyLw=="
+        },
         "convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -23264,8 +24792,40 @@
         "csstype": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-            "dev": true
+            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        },
+        "d3-color": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+            "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+        },
+        "d3-ease": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.7.tgz",
+            "integrity": "sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ=="
+        },
+        "d3-hierarchy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+            "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw=="
+        },
+        "d3-interpolate": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+            "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+            "requires": {
+                "d3-color": "1"
+            }
+        },
+        "d3-regression": {
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/d3-regression/-/d3-regression-1.3.10.tgz",
+            "integrity": "sha512-PF8GWEL70cHHWpx2jUQXc68r1pyPHIA+St16muk/XRokETzlegj5LriNKg7o4LR0TySug4nHYPJNNRz/W+/Niw=="
+        },
+        "d3-timer": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+            "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
         },
         "damerau-levenshtein": {
             "version": "1.0.8",
@@ -23294,13 +24854,25 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-            "peer": true
+            "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
         },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+        },
+        "deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "requires": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            }
         },
         "deep-is": {
             "version": "0.1.4",
@@ -23358,6 +24930,11 @@
                 "isobject": "^3.0.1"
             }
         },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ=="
+        },
         "denodeify": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
@@ -23373,6 +24950,11 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+        },
+        "detect-browser": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+            "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
         },
         "detect-node": {
             "version": "2.1.0",
@@ -23502,6 +25084,14 @@
                 "dotenv-defaults": "^2.0.2"
             }
         },
+        "dotignore": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+            "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+            "requires": {
+                "minimatch": "^3.0.4"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -23591,7 +25181,6 @@
             "version": "1.20.1",
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
             "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
@@ -23637,12 +25226,180 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-            "dev": true,
             "requires": {
                 "is-callable": "^1.1.4",
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
+        },
+        "esbuild": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+            "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+            "dev": true,
+            "requires": {
+                "@esbuild/linux-loong64": "0.14.54",
+                "esbuild-android-64": "0.14.54",
+                "esbuild-android-arm64": "0.14.54",
+                "esbuild-darwin-64": "0.14.54",
+                "esbuild-darwin-arm64": "0.14.54",
+                "esbuild-freebsd-64": "0.14.54",
+                "esbuild-freebsd-arm64": "0.14.54",
+                "esbuild-linux-32": "0.14.54",
+                "esbuild-linux-64": "0.14.54",
+                "esbuild-linux-arm": "0.14.54",
+                "esbuild-linux-arm64": "0.14.54",
+                "esbuild-linux-mips64le": "0.14.54",
+                "esbuild-linux-ppc64le": "0.14.54",
+                "esbuild-linux-riscv64": "0.14.54",
+                "esbuild-linux-s390x": "0.14.54",
+                "esbuild-netbsd-64": "0.14.54",
+                "esbuild-openbsd-64": "0.14.54",
+                "esbuild-sunos-64": "0.14.54",
+                "esbuild-windows-32": "0.14.54",
+                "esbuild-windows-64": "0.14.54",
+                "esbuild-windows-arm64": "0.14.54"
+            }
+        },
+        "esbuild-android-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+            "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-android-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+            "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+            "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+            "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+            "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+            "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+            "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+            "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+            "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+            "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+            "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+            "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+            "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+            "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+            "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+            "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+            "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+            "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+            "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+            "dev": true,
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.14.54",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+            "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+            "dev": true,
+            "optional": true
         },
         "escalade": {
             "version": "3.1.1",
@@ -24006,6 +25763,12 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true
         },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -24337,6 +26100,11 @@
                 "bser": "2.1.1"
             }
         },
+        "fecha": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+        },
         "file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -24442,11 +26210,31 @@
             "integrity": "sha512-1gIBiWJNR0tKUNv8gZuk7l9rVX06OuLzY9AoGio7y/JT4V1IZErEMEq2TJS+PFcw/y0RshZ1J/27VfK1UQzYVg==",
             "peer": true
         },
+        "fmin": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/fmin/-/fmin-0.0.2.tgz",
+            "integrity": "sha512-sSi6DzInhl9d8yqssDfGZejChO8d2bAGIpysPsvYsxFe898z89XhCZg6CPNV3nhUhFefeC/AXZK2bAJxlBjN6A==",
+            "requires": {
+                "contour_plot": "^0.0.1",
+                "json2module": "^0.0.3",
+                "rollup": "^0.25.8",
+                "tape": "^4.5.1",
+                "uglify-js": "^2.6.2"
+            }
+        },
         "follow-redirects": {
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
             "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
             "dev": true
+        },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
         },
         "for-in": {
             "version": "1.0.2",
@@ -24517,7 +26305,6 @@
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
             "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -24535,8 +26322,7 @@
         "functions-have-names": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "dev": true
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
         },
         "gensync": {
             "version": "1.0.0-beta.2",
@@ -24569,7 +26355,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
             "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "get-intrinsic": "^1.1.1"
@@ -24580,6 +26365,11 @@
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
             "peer": true
+        },
+        "gl-matrix": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+            "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
         },
         "glob": {
             "version": "7.2.3",
@@ -24652,11 +26442,25 @@
                 "function-bind": "^1.1.1"
             }
         },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+                }
+            }
+        },
         "has-bigints": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-            "dev": true
+            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
         },
         "has-flag": {
             "version": "3.0.0",
@@ -24680,7 +26484,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
             "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.2"
             }
@@ -25046,7 +26849,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
             "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-            "dev": true,
             "requires": {
                 "get-intrinsic": "^1.1.0",
                 "has": "^1.0.3",
@@ -25089,6 +26891,15 @@
                 "kind-of": "^6.0.0"
             }
         },
+        "is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -25099,7 +26910,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
             "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-            "dev": true,
             "requires": {
                 "has-bigints": "^1.0.1"
             }
@@ -25117,7 +26927,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
             "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -25126,14 +26935,12 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "peer": true
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-callable": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-            "dev": true
+            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
         },
         "is-core-module": {
             "version": "2.9.0",
@@ -25156,7 +26963,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
             "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "dev": true,
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
@@ -25223,8 +27029,7 @@
         "is-negative-zero": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-            "dev": true
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
         },
         "is-number": {
             "version": "7.0.0",
@@ -25235,7 +27040,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
             "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-            "dev": true,
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
@@ -25258,7 +27062,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -25268,7 +27071,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
             "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2"
             }
@@ -25283,7 +27085,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
             "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-            "dev": true,
             "requires": {
                 "has-tostringtag": "^1.0.0"
             }
@@ -25292,7 +27093,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
             "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-            "dev": true,
             "requires": {
                 "has-symbols": "^1.0.2"
             }
@@ -25307,7 +27107,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
             "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2"
             }
@@ -26004,6 +27803,14 @@
             "dev": true,
             "peer": true
         },
+        "json2module": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/json2module/-/json2module-0.0.3.tgz",
+            "integrity": "sha512-qYGxqrRrt4GbB8IEOy1jJGypkNsjWoIMlZt4bAsmUScCA507Hbc2p1JOhBzqn45u3PWafUgH2OnzyNU7udO/GA==",
+            "requires": {
+                "rw": "^1.3.2"
+            }
+        },
         "json2mq": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
@@ -26070,6 +27877,11 @@
             "requires": {
                 "language-subtag-registry": "~0.3.2"
             }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="
         },
         "leven": {
             "version": "3.1.0",
@@ -26207,6 +28019,11 @@
                 "dayjs": "^1.8.15",
                 "yargs": "^15.1.0"
             }
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha512-k+yt5n3l48JU4k8ftnKG6V7u32wyH2NfKzeMto9F/QRE0amxy/LayxwlvjjkZEIzqR+19IrtFO8p5kB9QaYUFg=="
         },
         "loose-envify": {
             "version": "1.4.0",
@@ -26832,8 +28649,7 @@
         "minimist": {
             "version": "1.2.6",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-            "peer": true
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "mixin-deep": {
             "version": "1.3.2",
@@ -27095,8 +28911,16 @@
         "object-inspect": {
             "version": "1.12.2",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-            "dev": true
+            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+        },
+        "object-is": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+            "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
         },
         "object-keys": {
             "version": "1.1.1",
@@ -27434,6 +29258,11 @@
             "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
             "dev": true
         },
+        "pdfast": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/pdfast/-/pdfast-0.2.0.tgz",
+            "integrity": "sha512-cq6TTu6qKSFUHwEahi68k/kqN2mfepjkGrG9Un70cgdRRKLKY6Rf8P8uvP2NvZktaQZNF3YE7agEkLj0vGK9bA=="
+        },
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -27463,6 +29292,12 @@
             "requires": {
                 "find-up": "^4.0.0"
             }
+        },
+        "playwright-core": {
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.25.0.tgz",
+            "integrity": "sha512-kZ3Jwaf3wlu0GgU0nB8UMQ+mXFTqBIFz9h1svTlNduNKjnbPXFxw7mJanLVjqxHJRn62uBfmgBj93YHidk2N5Q==",
+            "dev": true
         },
         "plist": {
             "version": "3.0.6",
@@ -28127,6 +29962,12 @@
                 "loose-envify": "^1.1.0"
             }
         },
+        "react-content-loader": {
+            "version": "5.1.4",
+            "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-5.1.4.tgz",
+            "integrity": "sha512-hTq7pZi2GKCK6a9d3u6XStozm0QGCEjw8cSqQReiWnh2up6IwCha5R5TF0o6SY5qUDpByloEZEZtnFxpJyENFw==",
+            "requires": {}
+        },
         "react-devtools-core": {
             "version": "4.24.0",
             "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
@@ -28297,7 +30138,6 @@
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
             "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
@@ -28372,8 +30212,7 @@
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-            "peer": true
+            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
         },
         "require-directory": {
             "version": "2.1.1",
@@ -28444,6 +30283,14 @@
                 "signal-exit": "^3.0.2"
             }
         },
+        "resumer": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+            "integrity": "sha512-Fn9X8rX8yYF4m81rZCK/5VmrmsSbqS/i3rDLl6ZZHAXgC2nTAx3dhwG8q8odP/RmdLa2YrybDJaAMg+X1ajY3w==",
+            "requires": {
+                "through": "~2.3.4"
+            }
+        },
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -28456,6 +30303,14 @@
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
             "dev": true
         },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha512-yqINtL/G7vs2v+dFIZmFUDbnVyFUJFKd6gK22Kgo6R4jfJGFtisKyncWDDULgjfqf4ASQuIQyjJ7XZ+3aWpsAg==",
+            "requires": {
+                "align-text": "^0.1.1"
+            }
+        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -28464,6 +30319,74 @@
             "requires": {
                 "glob": "^7.1.3"
             }
+        },
+        "rollup": {
+            "version": "0.25.8",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.25.8.tgz",
+            "integrity": "sha512-a2S4Bh3bgrdO4BhKr2E4nZkjTvrJ2m2bWjMTzVYtoqSCn0HnuxosXnaJUHrMEziOWr3CzL9GjilQQKcyCQpJoA==",
+            "requires": {
+                "chalk": "^1.1.1",
+                "minimist": "^1.2.0",
+                "source-map-support": "^0.3.2"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.32",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                    "integrity": "sha512-htQyLrrRLkQ87Zfrir4/yN+vAUd6DNjVayEjTSHXu29AYQJw57I4/xEL/M6p6E/woPNJwvZt6rVlzc7gFEJccQ==",
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                },
+                "source-map-support": {
+                    "version": "0.3.3",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.3.3.tgz",
+                    "integrity": "sha512-9O4+y9n64RewmFoKUZ/5Tx9IHIcXM6Q+RTSw6ehnqybUz4a7iwR3Eaw80uLtqqQ5D0C+5H03D4KKGo9PdP33Gg==",
+                    "requires": {
+                        "source-map": "0.1.32"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+                }
+            }
+        },
+        "rw": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+            "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
         },
         "rxjs": {
             "version": "7.5.5",
@@ -28781,7 +30704,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
             "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.0",
                 "get-intrinsic": "^1.0.2",
@@ -28798,6 +30720,11 @@
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "peer": true
+        },
+        "size-sensor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.1.tgz",
+            "integrity": "sha512-QTy7MnuugCFXIedXRpUSk9gUnyNiaxIdxGfUjr8xxXOqIB3QvBUYP9+b51oCg2C4dnhaeNk/h57TxjbvoJrJUA=="
         },
         "slash": {
             "version": "2.0.0",
@@ -29247,11 +31174,20 @@
                 "side-channel": "^1.0.4"
             }
         },
+        "string.prototype.trim": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
+            "integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
+            }
+        },
         "string.prototype.trimend": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
             "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
@@ -29262,7 +31198,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
             "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.4",
@@ -29341,6 +31276,28 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true
+        },
+        "tape": {
+            "version": "4.15.1",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-4.15.1.tgz",
+            "integrity": "sha512-k7F5pyr91n9D/yjSJwbLLYDCrTWXxMSXbbmHX2n334lSIc2rxeXyFkaBv4UuUd2gBYMrAOalPutAiCxC6q1qbw==",
+            "requires": {
+                "call-bind": "~1.0.2",
+                "deep-equal": "~1.1.1",
+                "defined": "~1.0.0",
+                "dotignore": "~0.1.2",
+                "for-each": "~0.3.3",
+                "glob": "~7.2.0",
+                "has": "~1.0.3",
+                "inherits": "~2.0.4",
+                "is-regex": "~1.1.4",
+                "minimist": "~1.2.6",
+                "object-inspect": "~1.12.0",
+                "resolve": "~1.22.0",
+                "resumer": "~0.0.0",
+                "string.prototype.trim": "~1.2.5",
+                "through": "~2.3.8"
+            }
         },
         "temp": {
             "version": "0.8.4",
@@ -29445,6 +31402,11 @@
             "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
             "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
             "peer": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
         },
         "through2": {
             "version": "2.0.5",
@@ -29691,11 +31653,59 @@
                 }
             }
         },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==",
+            "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                    "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g=="
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                    "integrity": "sha512-GIOYRizG+TGoc7Wgc1LiOTLare95R3mzKgoln+Q/lE4ceiYH19gUpl0l0Ffq4lJDEf3FxujMe6IBfOCs7pfqNA==",
+                    "requires": {
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
+                        "wordwrap": "0.0.2"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+                },
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "integrity": "sha512-QFzUah88GAGy9lyDKGBqZdkYApt63rCXYBGYnEP4xDJPXNqXXnBDACnbrXnViV6jRSqAePwrATi2i8mfYm4L1A==",
+                    "requires": {
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
+                        "window-size": "0.1.0"
+                    }
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha512-vb2s1lYx2xBtUgy+ta+b2J/GLVUR+wmpINwHePmPRhOsIVCG2wDzKJ0n14GslH1BifsqVzSOwQhRaCAsZ/nI4Q==",
+            "optional": true
+        },
         "unbox-primitive": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
             "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-            "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "has-bigints": "^1.0.2",
@@ -29895,6 +31905,30 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+        },
+        "vite": {
+            "version": "2.9.15",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
+            "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+            "dev": true,
+            "requires": {
+                "esbuild": "^0.14.27",
+                "fsevents": "~2.3.2",
+                "postcss": "^8.4.13",
+                "resolve": "^1.22.0",
+                "rollup": ">=2.59.0 <2.78.0"
+            },
+            "dependencies": {
+                "rollup": {
+                    "version": "2.77.3",
+                    "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+                    "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+                    "dev": true,
+                    "requires": {
+                        "fsevents": "~2.3.2"
+                    }
+                }
+            }
         },
         "vlq": {
             "version": "1.0.1",
@@ -30198,7 +32232,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
             "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-            "dev": true,
             "requires": {
                 "is-bigint": "^1.0.1",
                 "is-boolean-object": "^1.1.0",
@@ -30219,12 +32252,22 @@
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
         },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg=="
+        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
             "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
             "dev": true,
             "peer": true
+        },
+        "wordwrap": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+            "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q=="
         },
         "wrap-ansi": {
             "version": "6.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,7 @@
     "name": "how-many-buzzwords-ui",
     "version": "1.0.0",
     "dependencies": {
+        "@ant-design/plots": "1.2.1",
         "@apollo/client": "3.6.9",
         "@ashley-evans/buzzword-object-validator": "1.0.0",
         "@aws-amplify/auth": "4.5.9",
@@ -21,6 +22,7 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
+        "@playwright/experimental-ct-react": "^1.25.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/react": "^18.0.9",
@@ -44,6 +46,7 @@
     },
     "scripts": {
         "build": "./node_modules/.bin/webpack --mode=production --config webpack.config.js",
-        "start": "./node_modules/.bin/webpack serve --mode=development --config webpack.config.js"
+        "start": "./node_modules/.bin/webpack serve --mode=development --config webpack.config.js",
+        "test-ct": "playwright test -c playwright-ct.config.ts"
     }
 }

--- a/ui/playwright-ct.config.ts
+++ b/ui/playwright-ct.config.ts
@@ -1,0 +1,27 @@
+import type { PlaywrightTestConfig } from "@playwright/experimental-ct-react";
+import { devices } from "@playwright/experimental-ct-react";
+
+const config: PlaywrightTestConfig = {
+    testDir: "./tests/component/",
+    snapshotDir: "./tests/component/__snapshots__",
+    timeout: 10 * 1000,
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: "list",
+    use: {
+        trace: "on-first-retry",
+        ctPort: 3100,
+    },
+    projects: [
+        {
+            name: "chromium",
+            use: {
+                ...devices["Desktop Chrome"],
+            },
+        },
+    ],
+};
+
+export default config;

--- a/ui/playwright-ct.config.ts
+++ b/ui/playwright-ct.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
-    workers: process.env.CI ? 1 : undefined,
+    workers: process.env.CI ? 4 : undefined,
     reporter: "list",
     use: {
         trace: "on-first-retry",

--- a/ui/playwright/index.html
+++ b/ui/playwright/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Testing Page</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/playwright/index.ts"></script>
+    </body>
+</html>

--- a/ui/src/components/KeyphraseCloud.tsx
+++ b/ui/src/components/KeyphraseCloud.tsx
@@ -1,9 +1,14 @@
 import React, { Fragment } from "react";
+import { PathnameOccurrences } from "../clients/interfaces/KeyphraseServiceClient";
 
-function KeyphraseCloud() {
+type KeyphraseCloudProps = {
+    occurrences: PathnameOccurrences[];
+};
+
+function KeyphraseCloud(props: KeyphraseCloudProps) {
     return (
         <Fragment>
-            <p>Awaiting results...</p>
+            {props.occurrences.length == 0 && <p>Awaiting results...</p>}
         </Fragment>
     );
 }

--- a/ui/src/components/KeyphraseCloud.tsx
+++ b/ui/src/components/KeyphraseCloud.tsx
@@ -33,6 +33,7 @@ function KeyphraseCloud(props: KeyphraseCloudProps) {
         data: sumUniqueOccurrences(props.occurrences),
         wordField: "keyphrase",
         weightField: "occurrences",
+        colorField: "keyphrase",
         autoFit: false,
         renderer: "svg",
     };

--- a/ui/src/components/KeyphraseCloud.tsx
+++ b/ui/src/components/KeyphraseCloud.tsx
@@ -1,0 +1,11 @@
+import React, { Fragment } from "react";
+
+function KeyphraseCloud() {
+    return (
+        <Fragment>
+            <p>Awaiting results...</p>
+        </Fragment>
+    );
+}
+
+export default KeyphraseCloud;

--- a/ui/src/components/KeyphraseCloud.tsx
+++ b/ui/src/components/KeyphraseCloud.tsx
@@ -1,14 +1,50 @@
 import React, { Fragment } from "react";
+import { WordCloud, WordCloudConfig } from "@ant-design/plots";
+
 import { PathnameOccurrences } from "../clients/interfaces/KeyphraseServiceClient";
 
 type KeyphraseCloudProps = {
     occurrences: PathnameOccurrences[];
 };
 
+function sumUniqueOccurrences(
+    occurrences: PathnameOccurrences[]
+): Omit<PathnameOccurrences, "pathname">[] {
+    const result = occurrences.reduce((unique, current) => {
+        const currentTotal = unique.get(current.keyphrase);
+        unique.set(
+            current.keyphrase,
+            currentTotal
+                ? currentTotal + current.occurrences
+                : current.occurrences
+        );
+
+        return unique;
+    }, new Map<string, number>());
+
+    return Array.from(result, ([keyphrase, occurrences]) => ({
+        keyphrase,
+        occurrences,
+    }));
+}
+
 function KeyphraseCloud(props: KeyphraseCloudProps) {
+    const config: WordCloudConfig = {
+        data: sumUniqueOccurrences(props.occurrences),
+        wordField: "keyphrase",
+        weightField: "occurrences",
+        autoFit: false,
+        renderer: "svg",
+    };
+
     return (
         <Fragment>
             {props.occurrences.length == 0 && <p>Awaiting results...</p>}
+            {props.occurrences.length != 0 && (
+                <figure>
+                    <WordCloud {...config} />
+                </figure>
+            )}
         </Fragment>
     );
 }

--- a/ui/src/components/Results.tsx
+++ b/ui/src/components/Results.tsx
@@ -5,6 +5,7 @@ import { Button, Col, Row, Typography } from "antd";
 import { PathnameOccurrences } from "../clients/interfaces/KeyphraseServiceClient";
 import KeyphraseServiceClientFactory from "../clients/interfaces/KeyphraseServiceClientFactory";
 import OccurrenceTable from "./OccurrenceTable";
+import KeyphraseCloud from "./KeyphraseCloud";
 
 type ResultsProps = {
     keyphraseServiceClientFactory: KeyphraseServiceClientFactory;
@@ -52,6 +53,12 @@ function Results(props: ResultsProps) {
                         <Button>
                             <Link to="/">Return to search</Link>
                         </Button>
+                    </Col>
+                </Row>
+                <Row>
+                    <Col flex="1 1 500px" />
+                    <Col flex="1 0 500px">
+                        <KeyphraseCloud occurrences={occurrences} />
                     </Col>
                 </Row>
                 <Row>

--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -2,16 +2,21 @@ import React from "react";
 import { fireEvent, waitFor } from "@testing-library/react";
 import { mock } from "jest-mock-extended";
 import { from } from "rxjs";
+import path from "path";
 
-import App from "../App";
 import {
     renderWithMockProvider,
     createStatusUpdateMock,
     createStartCrawlMock,
+    mockComponent,
 } from "./helpers/utils";
 import KeyphraseServiceClientFactory from "../../clients/interfaces/KeyphraseServiceClientFactory";
 import { KeyphraseServiceClient } from "../../clients/interfaces/KeyphraseServiceClient";
 import CrawlStatus from "../../enums/CrawlStatus";
+
+mockComponent(path.join(__dirname, "..", "KeyphraseCloud"));
+
+import App from "../App";
 
 const APPLICATION_TITLE = "How many buzzwords";
 const URL_INPUT_LABEL = "URL";

--- a/ui/src/components/__tests__/KeyphraseCloud.test.tsx
+++ b/ui/src/components/__tests__/KeyphraseCloud.test.tsx
@@ -12,6 +12,12 @@ describe("given no occurrences", () => {
 
         expect(getByText(EXPECTED_AWAITING_MESSAGE)).toBeInTheDocument();
     });
+
+    test("does not render a word cloud figure", () => {
+        const { queryByRole } = render(<KeyphraseCloud occurrences={[]} />);
+
+        expect(queryByRole("figure")).not.toBeInTheDocument();
+    });
 });
 
 describe("given a single occurrence", () => {
@@ -30,4 +36,21 @@ describe("given a single occurrence", () => {
 
         expect(queryByText(EXPECTED_AWAITING_MESSAGE)).not.toBeInTheDocument();
     });
+
+    test("renders the word cloud figure", () => {
+        const { getByRole, getByText } = render(
+            <KeyphraseCloud occurrences={occurrences} />
+        );
+
+        expect(getByRole("figure")).toBeInTheDocument();
+
+        const test = getByText("wibble");
+
+        console.dir(test);
+    });
 });
+
+// TODO: Visual differences does not work as the chart is different every time the application is run
+// By converting to SVG, we can use getByText to get the rendered text in the graph
+// We can then check the size of the containing box, ensuring that the containers are larger
+// Past that, I have no idea what to be able test

--- a/ui/src/components/__tests__/KeyphraseCloud.test.tsx
+++ b/ui/src/components/__tests__/KeyphraseCloud.test.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import KeyphraseCloud from "../KeyphraseCloud";
+
+const EXPECTED_AWAITING_MESSAGE = "Awaiting results...";
+
+describe("given no occurrences", () => {
+    test("renders awaiting results message", () => {
+        const { getByText } = render(<KeyphraseCloud />);
+
+        expect(getByText(EXPECTED_AWAITING_MESSAGE)).toBeInTheDocument();
+    });
+});

--- a/ui/src/components/__tests__/KeyphraseCloud.test.tsx
+++ b/ui/src/components/__tests__/KeyphraseCloud.test.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import { render } from "@testing-library/react";
 
+jest.mock("@ant-design/plots", () => ({
+    __esModule: true,
+    WordCloud: () => {
+        return <></>;
+    },
+}));
+
 import KeyphraseCloud from "../KeyphraseCloud";
 import { PathnameOccurrences } from "../../clients/interfaces/KeyphraseServiceClient";
 
@@ -38,19 +45,10 @@ describe("given a single occurrence", () => {
     });
 
     test("renders the word cloud figure", () => {
-        const { getByRole, getByText } = render(
+        const { getByRole } = render(
             <KeyphraseCloud occurrences={occurrences} />
         );
 
         expect(getByRole("figure")).toBeInTheDocument();
-
-        const test = getByText("wibble");
-
-        console.dir(test);
     });
 });
-
-// TODO: Visual differences does not work as the chart is different every time the application is run
-// By converting to SVG, we can use getByText to get the rendered text in the graph
-// We can then check the size of the containing box, ensuring that the containers are larger
-// Past that, I have no idea what to be able test

--- a/ui/src/components/__tests__/KeyphraseCloud.test.tsx
+++ b/ui/src/components/__tests__/KeyphraseCloud.test.tsx
@@ -2,13 +2,32 @@ import React from "react";
 import { render } from "@testing-library/react";
 
 import KeyphraseCloud from "../KeyphraseCloud";
+import { PathnameOccurrences } from "../../clients/interfaces/KeyphraseServiceClient";
 
 const EXPECTED_AWAITING_MESSAGE = "Awaiting results...";
 
 describe("given no occurrences", () => {
     test("renders awaiting results message", () => {
-        const { getByText } = render(<KeyphraseCloud />);
+        const { getByText } = render(<KeyphraseCloud occurrences={[]} />);
 
         expect(getByText(EXPECTED_AWAITING_MESSAGE)).toBeInTheDocument();
+    });
+});
+
+describe("given a single occurrence", () => {
+    const occurrences: PathnameOccurrences[] = [
+        {
+            pathname: "/test",
+            keyphrase: "wibble",
+            occurrences: 10,
+        },
+    ];
+
+    test("does not render the awaiting results message", () => {
+        const { queryByText } = render(
+            <KeyphraseCloud occurrences={occurrences} />
+        );
+
+        expect(queryByText(EXPECTED_AWAITING_MESSAGE)).not.toBeInTheDocument();
     });
 });

--- a/ui/src/components/__tests__/helpers/utils.tsx
+++ b/ui/src/components/__tests__/helpers/utils.tsx
@@ -45,4 +45,22 @@ function createStartCrawlMock(started: boolean, url: string) {
     };
 }
 
-export { renderWithMockProvider, createStatusUpdateMock, createStartCrawlMock };
+function mockComponent<PropType>(
+    moduleName: string,
+    mockImplementation: jest.Mock = jest.fn()
+) {
+    const mockedComponent = (props: PropType) => {
+        mockImplementation(props);
+
+        return <></>;
+    };
+
+    jest.mock(moduleName, () => mockedComponent);
+}
+
+export {
+    renderWithMockProvider,
+    createStatusUpdateMock,
+    createStartCrawlMock,
+    mockComponent,
+};

--- a/ui/tests/component/KeyphraseCloud.test.tsx
+++ b/ui/tests/component/KeyphraseCloud.test.tsx
@@ -1,0 +1,146 @@
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react";
+
+import KeyphraseCloud from "../../src/components/KeyphraseCloud";
+import { PathnameOccurrences } from "../../src/clients/interfaces/KeyphraseServiceClient";
+
+test("should display a single keyphrase occurrence", async ({ mount }) => {
+    const expectedOccurrence: PathnameOccurrences = {
+        keyphrase: "test",
+        pathname: "/wibble",
+        occurrences: 15,
+    };
+
+    const component = await mount(
+        <KeyphraseCloud occurrences={[expectedOccurrence]} />
+    );
+
+    await expect(component).toContainText(expectedOccurrence.keyphrase);
+});
+
+test("should display multiple keyphrase occurrences", async ({ mount }) => {
+    const expectedOccurrence: PathnameOccurrences[] = [
+        {
+            keyphrase: "test",
+            pathname: "/wibble",
+            occurrences: 15,
+        },
+        {
+            keyphrase: "wibble",
+            pathname: "/test",
+            occurrences: 10,
+        },
+    ];
+
+    const component = await mount(
+        <KeyphraseCloud occurrences={expectedOccurrence} />
+    );
+
+    await expect(component).toContainText(expectedOccurrence[0].keyphrase);
+    await expect(component).toContainText(expectedOccurrence[1].keyphrase);
+});
+
+test("should only display unique keyphrase occurrences", async ({
+    mount,
+    page,
+}) => {
+    const expectedKeyphrase = "test";
+    const expectedOccurrence: PathnameOccurrences[] = [
+        {
+            keyphrase: expectedKeyphrase,
+            pathname: "/wibble",
+            occurrences: 15,
+        },
+        {
+            keyphrase: expectedKeyphrase,
+            pathname: "/test",
+            occurrences: 10,
+        },
+    ];
+
+    await mount(<KeyphraseCloud occurrences={expectedOccurrence} />);
+    const count = await page.locator(`text=${expectedKeyphrase}`).count();
+
+    expect(count).toEqual(1);
+});
+
+test("should size keyphrases based on number of occurrences given keyphrases from a single path", async ({
+    mount,
+    page,
+}) => {
+    const expectedSmallKeyphrase = "test";
+    const expectedLargeKeyphrase = "wibble";
+    const expectedOccurrence: PathnameOccurrences[] = [
+        {
+            keyphrase: expectedLargeKeyphrase,
+            pathname: "/test",
+            occurrences: 15,
+        },
+        {
+            keyphrase: expectedSmallKeyphrase,
+            pathname: "/test",
+            occurrences: 10,
+        },
+    ];
+
+    await mount(<KeyphraseCloud occurrences={expectedOccurrence} />);
+    const actualSmallCloudElement = await page
+        .locator(`text=${expectedSmallKeyphrase}`)
+        .boundingBox();
+    const actualLargeCloudElement = await page
+        .locator(`text=${expectedLargeKeyphrase}`)
+        .boundingBox();
+
+    expect(actualSmallCloudElement).toBeDefined();
+    expect(actualLargeCloudElement).toBeDefined();
+    if (actualSmallCloudElement && actualLargeCloudElement) {
+        expect(
+            actualSmallCloudElement.width * actualSmallCloudElement.height
+        ).toBeLessThan(
+            actualLargeCloudElement.width * actualLargeCloudElement.height
+        );
+    }
+});
+
+test("should size keyphrases based on number of occurrences given keyphrases from multiple paths", async ({
+    mount,
+    page,
+}) => {
+    const expectedSmallKeyphrase = "test";
+    const expectedLargeKeyphrase = "wibble";
+    const expectedOccurrence: PathnameOccurrences[] = [
+        {
+            keyphrase: expectedSmallKeyphrase,
+            pathname: "/test",
+            occurrences: 15,
+        },
+        {
+            keyphrase: expectedLargeKeyphrase,
+            pathname: "/test",
+            occurrences: 10,
+        },
+        {
+            keyphrase: expectedLargeKeyphrase,
+            pathname: "/wibble",
+            occurrences: 15,
+        },
+    ];
+
+    await mount(<KeyphraseCloud occurrences={expectedOccurrence} />);
+    const actualSmallCloudElement = await page
+        .locator(`text=${expectedSmallKeyphrase}`)
+        .boundingBox();
+    const actualLargeCloudElement = await page
+        .locator(`text=${expectedLargeKeyphrase}`)
+        .boundingBox();
+
+    expect(actualSmallCloudElement).toBeDefined();
+    expect(actualLargeCloudElement).toBeDefined();
+    if (actualSmallCloudElement && actualLargeCloudElement) {
+        expect(
+            actualSmallCloudElement.width * actualSmallCloudElement.height
+        ).toBeLessThan(
+            actualLargeCloudElement.width * actualLargeCloudElement.height
+        );
+    }
+});


### PR DESCRIPTION
Resolves #192 

# What

Added KeyphraseCloud component to display unique keyphrases in a word cloud, with each keyphrase's size weighted by the number of occurrences of that keyphrase across all paths
Updated Results page to render Keyphrase Cloud with results returned by keyphrase service
Add playwright configuration to allow browser component testing
Update UI pipeline to run playwright component tests

# Why

Word Cloud: To provide a different visualisation for the keyphrase result, beyond just the normal results table
Playwright: The library used to render the word cloud cannot be tested using JSDOM due to the use of web workers, therefore, playwright was added to enable testing the word cloud functionality
- Unfortunately means that the JSDOM tests are slightly more coupled to implementation as we need to mock use of KeyphraseCloud component across JSDOM tests.

CI pipeline: To ensure that playwright tests also pass before allowing merges or deployments to occur