### PR TITLE
Feature/249 total transaction

### DIFF
--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -112,27 +112,17 @@ class KeyphraseRepository implements Repository {
 
     async storeTotals(
         totals: KeyphraseOccurrences | KeyphraseOccurrences[],
-        baseURL?: string
+        baseURL: string
     ): Promise<boolean> {
-        if (baseURL) {
-            if (Array.isArray(totals)) {
-                const items = totals.map((total) =>
-                    this.createPageTotalItem(baseURL, total)
-                );
-                return this.storePageTotals(items);
-            }
-
-            const item = this.createPageTotalItem(baseURL, totals);
-            return this.storeIndividualPageTotal(item);
-        }
-
         if (Array.isArray(totals)) {
-            const items = totals.map((total) => this.createTotalItem(total));
-            return this.storeOccurrenceItems(items);
+            const items = totals.map((total) =>
+                this.createPageTotalItem(baseURL, total)
+            );
+            return this.storePageTotals(items);
         }
 
-        const item = this.createTotalItem(totals);
-        return this.storeIndividualKeyphrase(item);
+        const item = this.createPageTotalItem(baseURL, totals);
+        return this.storeIndividualPageTotal(item);
     }
 
     async getTotals(baseURL?: string): Promise<KeyphraseOccurrences[]> {
@@ -227,16 +217,6 @@ class KeyphraseRepository implements Repository {
 
             return false;
         }
-    }
-
-    private createTotalItem(
-        total: KeyphraseOccurrences
-    ): Partial<KeyphraseTableOccurrenceItem> {
-        return {
-            pk: KeyphraseTableConstants.TotalKey,
-            sk: total.keyphrase,
-            Occurrences: total.occurrences,
-        };
     }
 
     private createPageTotalItem(

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -113,8 +113,8 @@ class KeyphraseRepository implements Repository {
     }
 
     async storeTotals(
-        totals: KeyphraseOccurrences | KeyphraseOccurrences[],
-        baseURL: string
+        baseURL: string,
+        totals: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean> {
         if (Array.isArray(totals)) {
             const promises = totals.map((total) =>

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -266,8 +266,8 @@ describe("GET TOTAL: Only returns totals related to provided base URL", () => {
     const expectedTotal = TEST_KEYPHRASES[0];
 
     beforeAll(async () => {
-        await repository.storeTotals(expectedTotal, VALID_URL.hostname);
-        await repository.storeTotals(TEST_KEYPHRASES[1], OTHER_URL.hostname);
+        await repository.storeTotals(VALID_URL.hostname, expectedTotal);
+        await repository.storeTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
     });
 
     test("get returns only totals associated with provied base URL", async () => {
@@ -293,7 +293,7 @@ describe.each([
 
         beforeAll(async () => {
             for (const page of pages) {
-                await repository.storeTotals(expectedKeyphrase, page);
+                await repository.storeTotals(page, expectedKeyphrase);
             }
         });
 
@@ -317,11 +317,11 @@ describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
     const expectedPage = VALID_URL.hostname;
 
     beforeAll(async () => {
-        await repository.storeTotals(expectedKeyphrase, expectedPage);
-        await repository.storeTotals(TEST_KEYPHRASES[1], OTHER_URL.hostname);
+        await repository.storeTotals(expectedPage, expectedKeyphrase);
+        await repository.storeTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
     });
 
-    test("get returns only totals associated with provied base URL", async () => {
+    test("get returns only totals associated with provided base URL", async () => {
         const response = await repository.getKeyphraseUsages(
             expectedKeyphrase.keyphrase
         );
@@ -502,15 +502,15 @@ describe("total handling", () => {
         ) => {
             test("returns success when total storage succeeds", async () => {
                 const actual = await repository.storeTotals(
-                    input,
-                    VALID_URL.hostname
+                    VALID_URL.hostname,
+                    input
                 );
 
                 expect(actual).toBe(true);
             });
 
             test("stores page totals successfully", async () => {
-                await repository.storeTotals(input, VALID_URL.hostname);
+                await repository.storeTotals(VALID_URL.hostname, input);
 
                 const stored = await repository.getTotals(VALID_URL.hostname);
 
@@ -518,7 +518,7 @@ describe("total handling", () => {
             });
 
             test("stores global total successfully", async () => {
-                await repository.storeTotals(input, VALID_URL.hostname);
+                await repository.storeTotals(VALID_URL.hostname, input);
 
                 const stored = await repository.getTotals();
 
@@ -536,11 +536,11 @@ describe("total handling", () => {
             message: string,
             pageTotals: KeyphraseOccurrences | KeyphraseOccurrences[]
         ) => {
-            await repository.storeTotals(pageTotals, VALID_URL.hostname);
+            await repository.storeTotals(VALID_URL.hostname, pageTotals);
 
             const actual = await repository.storeTotals(
-                pageTotals,
-                VALID_URL.hostname
+                VALID_URL.hostname,
+                pageTotals
             );
 
             expect(actual).toBe(true);
@@ -558,11 +558,11 @@ describe("total handling", () => {
                     keyphrase: TEST_KEYPHRASES[0].keyphrase,
                     occurrences: TEST_KEYPHRASES[0].occurrences + 1,
                 };
-                await repository.storeTotals(existingTotal, VALID_URL.hostname);
+                await repository.storeTotals(VALID_URL.hostname, existingTotal);
 
                 await repository.storeTotals(
-                    TEST_KEYPHRASES[0],
-                    VALID_URL.hostname
+                    VALID_URL.hostname,
+                    TEST_KEYPHRASES[0]
                 );
                 const stored = await repository.getTotals(baseURL);
 
@@ -582,13 +582,13 @@ describe("total handling", () => {
                     return keyphrase;
                 });
                 await repository.storeTotals(
-                    existingTotals,
-                    VALID_URL.hostname
+                    VALID_URL.hostname,
+                    existingTotals
                 );
 
                 await repository.storeTotals(
-                    TEST_KEYPHRASES,
-                    VALID_URL.hostname
+                    VALID_URL.hostname,
+                    TEST_KEYPHRASES
                 );
                 const stored = await repository.getTotals(baseURL);
 
@@ -604,8 +604,8 @@ describe("total handling", () => {
         });
 
         const actual = await repository.storeTotals(
-            TEST_KEYPHRASES[0],
-            VALID_URL.hostname
+            VALID_URL.hostname,
+            TEST_KEYPHRASES[0]
         );
         putItemSpy.mockRestore();
 
@@ -619,8 +619,8 @@ describe("total handling", () => {
         });
 
         const actual = await repository.storeTotals(
-            TEST_KEYPHRASES,
-            VALID_URL.hostname
+            VALID_URL.hostname,
+            TEST_KEYPHRASES
         );
         putItemSpy.mockRestore();
 
@@ -700,7 +700,7 @@ describe("empty table behaviour", () => {
             occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
         ) => {
             beforeEach(async () => {
-                await repository.storeTotals(occurrences, VALID_URL.hostname);
+                await repository.storeTotals(VALID_URL.hostname, occurrences);
             });
 
             test("returns success", async () => {

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -83,7 +83,7 @@ describe.each([
         });
 
         afterAll(async () => {
-            await repository.deleteKeyphrases(VALID_URL.hostname);
+            await repository.empty();
         });
     }
 );
@@ -121,7 +121,7 @@ describe("GET ALL: given keyphrases occurrences stored against multiple paths on
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -153,8 +153,7 @@ describe("GET ALL: given keyphrase occurrences stored for multiple URLs", () => 
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
-        await repository.deleteKeyphrases(OTHER_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -189,7 +188,7 @@ describe.each([
         });
 
         afterAll(async () => {
-            await repository.deleteKeyphrases(VALID_URL.hostname);
+            await repository.empty();
         });
     }
 );
@@ -224,7 +223,7 @@ describe("GET PATH: given keyphrase occurrences stored for multiple paths on sam
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -259,8 +258,7 @@ describe("GET PATH: given keyphrase occurrences stored for same path on multiple
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
-        await repository.deleteKeyphrases(OTHER_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -280,8 +278,7 @@ describe("GET TOTAL: Only returns totals related to provided base URL", () => {
     });
 
     afterAll(async () => {
-        await repository.deleteTotals(VALID_URL.hostname);
-        await repository.deleteTotals(OTHER_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -310,9 +307,7 @@ describe.each([
         });
 
         afterAll(async () => {
-            for (const page of pages) {
-                await repository.deleteTotals(page);
-            }
+            await repository.empty();
         });
     }
 );
@@ -336,8 +331,7 @@ describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
     });
 
     afterAll(async () => {
-        await repository.deleteTotals(expectedPage);
-        await repository.deleteTotals(OTHER_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -368,7 +362,7 @@ describe("PUT: Stores new keyphrase occurrence", () => {
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -405,7 +399,7 @@ describe("PUT: Overwrites existing keyphrase occurrence", () => {
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
+        await repository.empty();
     });
 });
 
@@ -443,7 +437,7 @@ describe.each([
         });
 
         afterAll(async () => {
-            await repository.deleteKeyphrases(VALID_URL.hostname);
+            await repository.empty();
         });
     }
 );
@@ -482,128 +476,13 @@ describe("PUT: Overwrites existing keyphrase occurrences given multiple stored s
     });
 
     afterAll(async () => {
-        await repository.deleteKeyphrases(VALID_URL.hostname);
-    });
-});
-
-describe.each([
-    ["one occurrence", [TEST_KEYPHRASES[0]]],
-    ["less than 25 occurrences", createRandomOccurrences(24)],
-    ["greater than 25 occurrences", createRandomOccurrences(26)],
-])(
-    "DELETE: given %s stored for URL",
-    (message: string, occurrences: KeyphraseOccurrences[]) => {
-        let response: boolean;
-
-        beforeAll(async () => {
-            await repository.storeKeyphrases(
-                VALID_URL.hostname,
-                VALID_URL.pathname,
-                occurrences
-            );
-
-            response = await repository.deleteKeyphrases(VALID_URL.hostname);
-        });
-
-        test("returns no pathnames following deletion", async () => {
-            const result = await repository.getKeyphrases(VALID_URL.hostname);
-
-            expect(result).toHaveLength(0);
-        });
-
-        test("returns success", () => {
-            expect(response).toEqual(true);
-        });
-    }
-);
-
-describe("DELETE: given keyphrases occurrences stored against multiple paths on base URL", () => {
-    const OTHER_PATHNAME = `${VALID_URL.pathname}1`;
-
-    let response: boolean;
-
-    beforeAll(async () => {
-        await repository.storeKeyphrases(
-            VALID_URL.hostname,
-            VALID_URL.pathname,
-            TEST_KEYPHRASES[0]
-        );
-        await repository.storeKeyphrases(
-            VALID_URL.hostname,
-            OTHER_PATHNAME,
-            TEST_KEYPHRASES[1]
-        );
-
-        response = await repository.deleteKeyphrases(VALID_URL.hostname);
-    });
-
-    test("returns no pathnames following deletion", async () => {
-        const result = await repository.getKeyphrases(VALID_URL.hostname);
-
-        expect(result).toHaveLength(0);
-    });
-
-    test("returns success", () => {
-        expect(response).toEqual(true);
-    });
-});
-
-test("DELETE: returns failure given no keyphrase occurrences stored", async () => {
-    const response = await repository.deleteKeyphrases(VALID_URL.hostname);
-
-    expect(response).toEqual(false);
-});
-
-describe("DELETE: only effects associated keyphrase occurrences", () => {
-    const expectedKeyphrase = TEST_KEYPHRASES[1];
-
-    let response: boolean;
-
-    beforeAll(async () => {
-        await repository.storeKeyphrases(
-            VALID_URL.hostname,
-            VALID_URL.pathname,
-            TEST_KEYPHRASES[0]
-        );
-        await repository.storeKeyphrases(
-            OTHER_URL.hostname,
-            OTHER_URL.pathname,
-            expectedKeyphrase
-        );
-
-        response = await repository.deleteKeyphrases(VALID_URL.hostname);
-    });
-
-    test("returns no keyphrase occurrences for affected URL", async () => {
-        const result = await repository.getKeyphrases(VALID_URL.hostname);
-
-        expect(result).toHaveLength(0);
-    });
-
-    test("returns keyphrase occurrences for non-affected URL", async () => {
-        const result = await repository.getKeyphrases(OTHER_URL.hostname);
-
-        expect(result).toHaveLength(1);
-        expect(result[0]).toEqual({
-            pathname: OTHER_URL.pathname,
-            keyphrase: expectedKeyphrase.keyphrase,
-            occurrences: expectedKeyphrase.occurrences,
-        });
-    });
-
-    test("deletion returns success", () => {
-        expect(response).toEqual(true);
-    });
-
-    afterAll(async () => {
-        await repository.deleteKeyphrases(OTHER_URL.hostname);
+        await repository.empty();
     });
 });
 
 describe("total handling", () => {
     beforeEach(async () => {
-        await repository.deleteTotals();
-        await repository.deleteTotals(VALID_URL.hostname);
+        await repository.empty();
     });
 
     test.each([
@@ -695,55 +574,6 @@ describe("total handling", () => {
         expect(stored).toEqual(TEST_KEYPHRASES);
     });
 
-    test.each([
-        ["a single page total", TEST_KEYPHRASES[0]],
-        ["less than 25 totals", TEST_KEYPHRASES],
-        ["greater than 25 totals", TEST_BATCH_KEYPHRASES],
-    ])(
-        "returns success when total deletion succeeds given %s stored",
-        async (
-            message: string,
-            existing: KeyphraseOccurrences | KeyphraseOccurrences[]
-        ) => {
-            await repository.storeTotals(existing, VALID_URL.hostname);
-
-            const actual = await repository.deleteTotals(VALID_URL.hostname);
-
-            expect(actual).toBe(true);
-        }
-    );
-
-    test.each([
-        ["a single page total", TEST_KEYPHRASES[0]],
-        ["less than 25 totals", TEST_KEYPHRASES],
-        ["greater than 25 totals", TEST_BATCH_KEYPHRASES],
-    ])(
-        "removes page totals successfully given %s stored",
-        async (
-            message: string,
-            input: KeyphraseOccurrences | KeyphraseOccurrences[]
-        ) => {
-            await repository.storeTotals(input, VALID_URL.hostname);
-
-            await repository.deleteTotals(VALID_URL.hostname);
-            const stored = await repository.getTotals(VALID_URL.hostname);
-
-            expect(stored).toHaveLength(0);
-        }
-    );
-
-    test.each([
-        ["global totals", undefined],
-        ["page totals", VALID_URL.hostname],
-    ])(
-        "returns failure given no %s stored",
-        async (message: string, baseURL?: string) => {
-            const actual = await repository.deleteTotals(baseURL);
-
-            expect(actual).toBe(false);
-        }
-    );
-
     test("returns failure when storage fails given a single page total", async () => {
         const putItemSpy = jest.spyOn(dynamoDB, "putItem");
         putItemSpy.mockImplementation(() => {
@@ -795,7 +625,80 @@ describe("total handling", () => {
     );
 
     afterEach(async () => {
-        await repository.deleteTotals();
-        await repository.deleteTotals(VALID_URL.hostname);
+        await repository.empty();
     });
+});
+
+describe("Empty table behaviour", () => {
+    describe.each([
+        ["nothing", []],
+        ["a single keyphrase occurrence", TEST_KEYPHRASES[0]],
+        ["less than 25 occurrences", TEST_KEYPHRASES],
+        ["more than 25 occurrences", TEST_BATCH_KEYPHRASES],
+    ])(
+        "Empty clears all keyphrase occurrences given %s stored",
+        (
+            message: string,
+            occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
+        ) => {
+            beforeEach(async () => {
+                await repository.storeKeyphrases(
+                    VALID_URL.hostname,
+                    VALID_URL.pathname,
+                    occurrences
+                );
+            });
+
+            test("returns success", async () => {
+                const actual = await repository.empty();
+
+                expect(actual).toBe(true);
+            });
+
+            test("empties table of occurrences", async () => {
+                await repository.empty();
+                const actual = await repository.getKeyphrases(
+                    VALID_URL.hostname
+                );
+
+                expect(actual).toHaveLength(0);
+            });
+        }
+    );
+
+    describe.each([
+        ["a single total", TEST_KEYPHRASES[0]],
+        ["less than 25 totals", TEST_KEYPHRASES],
+        ["more than 25 totals", TEST_BATCH_KEYPHRASES],
+    ])(
+        "Empty clears all totals given %s stored",
+        (
+            message: string,
+            occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
+        ) => {
+            beforeEach(async () => {
+                await repository.storeTotals(occurrences, VALID_URL.hostname);
+            });
+
+            test("returns success", async () => {
+                const actual = await repository.empty();
+
+                expect(actual).toBe(true);
+            });
+
+            test("empties table of page totals", async () => {
+                await repository.empty();
+                const actual = await repository.getTotals(VALID_URL.hostname);
+
+                expect(actual).toHaveLength(0);
+            });
+
+            test("empties table of global totals", async () => {
+                await repository.empty();
+                const actual = await repository.getTotals();
+
+                expect(actual).toHaveLength(0);
+            });
+        }
+    );
 });

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -10,7 +10,7 @@ type PathnameOccurrences = {
 };
 
 interface Repository {
-    deleteKeyphrases(baseURL: string, skPrefix?: string): Promise<boolean>;
+    empty(): Promise<boolean>;
     getKeyphrases(baseURL: string): Promise<PathnameOccurrences[]>;
     getPathKeyphrases(
         baseURL: string,
@@ -21,7 +21,6 @@ interface Repository {
         pathname: string,
         occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;
-    deleteTotals(baseURL?: string): Promise<boolean>;
     getTotals(baseURL: string): Promise<KeyphraseOccurrences[]>;
     storeTotals(
         totals: KeyphraseOccurrences | KeyphraseOccurrences[],

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -22,7 +22,7 @@ interface Repository {
         occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;
     deleteTotals(baseURL?: string): Promise<boolean>;
-    getTotals(baseURL?: string): Promise<KeyphraseOccurrences[]>;
+    getTotals(baseURL: string): Promise<KeyphraseOccurrences[]>;
     storeTotals(
         totals: KeyphraseOccurrences | KeyphraseOccurrences[],
         baseURL?: string

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -23,8 +23,8 @@ interface Repository {
     ): Promise<boolean>;
     getTotals(baseURL: string): Promise<KeyphraseOccurrences[]>;
     storeTotals(
-        totals: KeyphraseOccurrences | KeyphraseOccurrences[],
-        baseURL?: string
+        baseURL: string,
+        totals: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;
     getKeyphraseUsages(keyphrase: string): Promise<string[]>;
 }

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -21,7 +21,7 @@ interface Repository {
         pathname: string,
         occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;
-    getTotals(baseURL: string): Promise<KeyphraseOccurrences[]>;
+    getTotals(baseURL?: string): Promise<KeyphraseOccurrences[]>;
     storeTotals(
         baseURL: string,
         totals: KeyphraseOccurrences | KeyphraseOccurrences[]


### PR DESCRIPTION
Resolves #249 

# What

Updated KeyphraseRepository to: 
- Store both page and global total value in a single transaction
- Replace individual occurrence and total deletion methods with one empty method

# Why

To ensure that global totals are kept up to date with page totals

Empty method: To reduce complexity of code required to empty table contents
