### PR TITLE
Feature/260 keyphrase total counter

### DIFF
--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -115,7 +115,7 @@ class KeyphraseRepository implements Repository {
         return this.storeIndividualKeyphrase(item);
     }
 
-    async storeTotals(
+    async addTotals(
         baseURL: string,
         totals: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean> {

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -283,27 +283,27 @@ describe("GET TOTAL: Only returns totals related to provided base URL", () => {
 });
 
 describe.each([
-    ["no pages", []],
-    ["one page", [VALID_URL.hostname]],
-    ["multiple pages", [VALID_URL.hostname, OTHER_URL.hostname]],
+    ["no sites", []],
+    ["one site", [VALID_URL.hostname]],
+    ["multiple sites", [VALID_URL.hostname, OTHER_URL.hostname]],
 ])(
     "GET USAGES: given keyphrase used on %s",
-    (message: string, pages: string[]) => {
+    (message: string, sites: string[]) => {
         const expectedKeyphrase = TEST_KEYPHRASES[0];
 
         beforeAll(async () => {
-            for (const page of pages) {
-                await repository.addTotals(page, expectedKeyphrase);
+            for (const site of sites) {
+                await repository.addTotals(site, expectedKeyphrase);
             }
         });
 
-        test("get returns all pages keyphrase is used on", async () => {
+        test("get returns all sites keyphrase is used on", async () => {
             const response = await repository.getKeyphraseUsages(
                 expectedKeyphrase.keyphrase
             );
 
-            expect(response).toHaveLength(pages.length);
-            expect(response).toEqual(pages);
+            expect(response).toHaveLength(sites.length);
+            expect(response).toEqual(sites);
         });
 
         afterAll(async () => {
@@ -314,10 +314,10 @@ describe.each([
 
 describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
     const expectedKeyphrase = TEST_KEYPHRASES[0];
-    const expectedPage = VALID_URL.hostname;
+    const expectedSite = VALID_URL.hostname;
 
     beforeAll(async () => {
-        await repository.addTotals(expectedPage, expectedKeyphrase);
+        await repository.addTotals(expectedSite, expectedKeyphrase);
         await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
     });
 
@@ -327,7 +327,7 @@ describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
         );
 
         expect(response).toHaveLength(1);
-        expect(response[0]).toEqual(expectedPage);
+        expect(response[0]).toEqual(expectedSite);
     });
 
     afterAll(async () => {
@@ -509,7 +509,7 @@ describe("total handling", () => {
                 expect(actual).toBe(true);
             });
 
-            test("stores page totals successfully", async () => {
+            test("stores site totals successfully", async () => {
                 await repository.addTotals(VALID_URL.hostname, input);
 
                 const stored = await repository.getTotals(VALID_URL.hostname);
@@ -534,13 +534,13 @@ describe("total handling", () => {
         "returns success when total storage succeeds given %s that have been stored before",
         async (
             message: string,
-            pageTotals: KeyphraseOccurrences | KeyphraseOccurrences[]
+            totals: KeyphraseOccurrences | KeyphraseOccurrences[]
         ) => {
-            await repository.addTotals(VALID_URL.hostname, pageTotals);
+            await repository.addTotals(VALID_URL.hostname, totals);
 
             const actual = await repository.addTotals(
                 VALID_URL.hostname,
-                pageTotals
+                totals
             );
 
             expect(actual).toBe(true);
@@ -641,7 +641,7 @@ describe("total handling", () => {
 
     test.each([
         ["global totals", undefined],
-        ["page totals", VALID_URL.hostname],
+        ["site totals", VALID_URL.hostname],
     ])(
         "throws an error when an unexpected error occurs while retrieving %s",
         async (message: string, baseURL?: string) => {
@@ -721,7 +721,7 @@ describe("empty table behaviour", () => {
                 expect(actual).toBe(true);
             });
 
-            test("empties table of page totals", async () => {
+            test("empties table of site totals", async () => {
                 await repository.empty();
                 const actual = await repository.getTotals(VALID_URL.hostname);
 

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -266,8 +266,8 @@ describe("GET TOTAL: Only returns totals related to provided base URL", () => {
     const expectedTotal = TEST_KEYPHRASES[0];
 
     beforeAll(async () => {
-        await repository.storeTotals(VALID_URL.hostname, expectedTotal);
-        await repository.storeTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
+        await repository.addTotals(VALID_URL.hostname, expectedTotal);
+        await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
     });
 
     test("get returns only totals associated with provied base URL", async () => {
@@ -293,7 +293,7 @@ describe.each([
 
         beforeAll(async () => {
             for (const page of pages) {
-                await repository.storeTotals(page, expectedKeyphrase);
+                await repository.addTotals(page, expectedKeyphrase);
             }
         });
 
@@ -317,8 +317,8 @@ describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
     const expectedPage = VALID_URL.hostname;
 
     beforeAll(async () => {
-        await repository.storeTotals(expectedPage, expectedKeyphrase);
-        await repository.storeTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
+        await repository.addTotals(expectedPage, expectedKeyphrase);
+        await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
     });
 
     test("get returns only totals associated with provided base URL", async () => {
@@ -501,7 +501,7 @@ describe("total handling", () => {
             expected: KeyphraseOccurrences[]
         ) => {
             test("returns success when total storage succeeds", async () => {
-                const actual = await repository.storeTotals(
+                const actual = await repository.addTotals(
                     VALID_URL.hostname,
                     input
                 );
@@ -510,7 +510,7 @@ describe("total handling", () => {
             });
 
             test("stores page totals successfully", async () => {
-                await repository.storeTotals(VALID_URL.hostname, input);
+                await repository.addTotals(VALID_URL.hostname, input);
 
                 const stored = await repository.getTotals(VALID_URL.hostname);
 
@@ -518,7 +518,7 @@ describe("total handling", () => {
             });
 
             test("stores global total successfully", async () => {
-                await repository.storeTotals(VALID_URL.hostname, input);
+                await repository.addTotals(VALID_URL.hostname, input);
 
                 const stored = await repository.getTotals();
 
@@ -536,9 +536,9 @@ describe("total handling", () => {
             message: string,
             pageTotals: KeyphraseOccurrences | KeyphraseOccurrences[]
         ) => {
-            await repository.storeTotals(VALID_URL.hostname, pageTotals);
+            await repository.addTotals(VALID_URL.hostname, pageTotals);
 
-            const actual = await repository.storeTotals(
+            const actual = await repository.addTotals(
                 VALID_URL.hostname,
                 pageTotals
             );
@@ -553,12 +553,9 @@ describe("total handling", () => {
                 keyphrase: TEST_KEYPHRASES[0].keyphrase,
                 occurrences: TEST_KEYPHRASES[0].occurrences + 1,
             };
-            await repository.storeTotals(VALID_URL.hostname, existingTotal);
+            await repository.addTotals(VALID_URL.hostname, existingTotal);
 
-            await repository.storeTotals(
-                VALID_URL.hostname,
-                TEST_KEYPHRASES[0]
-            );
+            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
             const stored = await repository.getTotals(VALID_URL.hostname);
 
             expect(stored).toHaveLength(1);
@@ -570,24 +567,18 @@ describe("total handling", () => {
                 keyphrase.occurrences += 1;
                 return keyphrase;
             });
-            await repository.storeTotals(VALID_URL.hostname, existingTotals);
+            await repository.addTotals(VALID_URL.hostname, existingTotals);
 
-            await repository.storeTotals(VALID_URL.hostname, TEST_KEYPHRASES);
+            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
             const stored = await repository.getTotals(VALID_URL.hostname);
 
             expect(stored).toEqual(TEST_KEYPHRASES);
         });
 
         test("increments existing global keyphrase total given a new occurrence on a different base URL", async () => {
-            await repository.storeTotals(
-                VALID_URL.hostname,
-                TEST_KEYPHRASES[0]
-            );
+            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
 
-            await repository.storeTotals(
-                OTHER_URL.hostname,
-                TEST_KEYPHRASES[0]
-            );
+            await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[0]);
             const stored = await repository.getTotals();
 
             expect(stored).toHaveLength(1);
@@ -598,9 +589,9 @@ describe("total handling", () => {
         });
 
         test("increments existing global keyphrase totals given new occurrences on a different base URL", async () => {
-            await repository.storeTotals(VALID_URL.hostname, TEST_KEYPHRASES);
+            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
 
-            await repository.storeTotals(OTHER_URL.hostname, TEST_KEYPHRASES);
+            await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES);
             const stored = await repository.getTotals();
 
             expect(stored).toHaveLength(2);
@@ -621,7 +612,7 @@ describe("total handling", () => {
             throw new Error("test error");
         });
 
-        const actual = await repository.storeTotals(
+        const actual = await repository.addTotals(
             VALID_URL.hostname,
             TEST_KEYPHRASES[0]
         );
@@ -636,7 +627,7 @@ describe("total handling", () => {
             throw new Error("test error");
         });
 
-        const actual = await repository.storeTotals(
+        const actual = await repository.addTotals(
             VALID_URL.hostname,
             TEST_KEYPHRASES
         );
@@ -718,7 +709,7 @@ describe("empty table behaviour", () => {
             occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
         ) => {
             beforeEach(async () => {
-                await repository.storeTotals(VALID_URL.hostname, occurrences);
+                await repository.addTotals(VALID_URL.hostname, occurrences);
             });
 
             test("returns success", async () => {

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -548,31 +548,34 @@ describe("total handling", () => {
     );
 
     describe("existing total storage", () => {
-        test("overwrites single page total if already exists", async () => {
-            const existingTotal: KeyphraseOccurrences = {
-                keyphrase: TEST_KEYPHRASES[0].keyphrase,
-                occurrences: TEST_KEYPHRASES[0].occurrences + 1,
-            };
-            await repository.addTotals(VALID_URL.hostname, existingTotal);
+        test("increments site total given existing site total", async () => {
+            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
 
             await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
             const stored = await repository.getTotals(VALID_URL.hostname);
 
             expect(stored).toHaveLength(1);
-            expect(stored[0]).toEqual(TEST_KEYPHRASES[0]);
+            expect(stored[0]).toEqual({
+                keyphrase: TEST_KEYPHRASES[0].keyphrase,
+                occurrences: TEST_KEYPHRASES[0].occurrences * 2,
+            });
         });
 
-        test("overwrites all existing page totals given multiple clashing totals", async () => {
-            const existingTotals = TEST_KEYPHRASES.map((keyphrase) => {
-                keyphrase.occurrences += 1;
-                return keyphrase;
-            });
-            await repository.addTotals(VALID_URL.hostname, existingTotals);
+        test("increments site totals given existing site totals", async () => {
+            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
 
             await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
             const stored = await repository.getTotals(VALID_URL.hostname);
 
-            expect(stored).toEqual(TEST_KEYPHRASES);
+            expect(stored).toHaveLength(2);
+            expect(stored[0]).toEqual({
+                keyphrase: TEST_KEYPHRASES[0].keyphrase,
+                occurrences: TEST_KEYPHRASES[0].occurrences * 2,
+            });
+            expect(stored[1]).toEqual({
+                keyphrase: TEST_KEYPHRASES[1].keyphrase,
+                occurrences: TEST_KEYPHRASES[1].occurrences * 2,
+            });
         });
 
         test("increments existing global keyphrase total given a new occurrence on a different base URL", async () => {

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -22,7 +22,7 @@ interface Repository {
         occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;
     getTotals(baseURL?: string): Promise<KeyphraseOccurrences[]>;
-    storeTotals(
+    addTotals(
         baseURL: string,
         totals: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;


### PR DESCRIPTION
Resolves #260 

# What

Updated KeyphraseRepository total storage to increment total for given keyphrase by the amount provided rather than overwrite
- Affects site and global totals for that keyphrase
- Requires consumers to provide the amount to increase/decrease the current total value. Meaning that consumers will need to first get the current value and compare with new

# Why

To allow the totalling of the number of occurrences of a given keyphrase across any given site or globally across all sites