### PR TITLE
Feature/265 prevent duplicate total addition

### DIFF
--- a/services/keyphrase/functions/new-connection/domain/NewConnectionDomain.ts
+++ b/services/keyphrase/functions/new-connection/domain/NewConnectionDomain.ts
@@ -33,7 +33,7 @@ class NewConnectionDomain implements NewConnectionPort {
         }
 
         try {
-            const occurrences = await this.repository.getKeyphrases(
+            const occurrences = await this.repository.getOccurrences(
                 connections.baseURL
             );
 
@@ -115,7 +115,7 @@ class NewConnectionDomain implements NewConnectionPort {
 
         const result = new Map();
         for (const baseURL of uniqueBaseURLs) {
-            const occurrences = await this.repository.getKeyphrases(baseURL);
+            const occurrences = await this.repository.getOccurrences(baseURL);
             result.set(baseURL, occurrences);
         }
 

--- a/services/keyphrase/functions/new-connection/domain/__tests__/NewConnectionDomain.test.ts
+++ b/services/keyphrase/functions/new-connection/domain/__tests__/NewConnectionDomain.test.ts
@@ -64,7 +64,7 @@ describe("given a single new connection listening to a base URL", () => {
         beforeAll(async () => {
             jest.resetAllMocks();
             mockClientFactory.createClient.mockReturnValue(mockClient);
-            mockRepository.getKeyphrases.mockResolvedValue([]);
+            mockRepository.getOccurrences.mockResolvedValue([]);
 
             const domain = new NewConnectionDomain(
                 mockClientFactory,
@@ -74,8 +74,8 @@ describe("given a single new connection listening to a base URL", () => {
         });
 
         test("calls repository to obtain current keyphrase state for base URL", () => {
-            expect(mockRepository.getKeyphrases).toHaveBeenCalledTimes(1);
-            expect(mockRepository.getKeyphrases).toHaveBeenCalledWith(
+            expect(mockRepository.getOccurrences).toHaveBeenCalledTimes(1);
+            expect(mockRepository.getOccurrences).toHaveBeenCalledWith(
                 connection.baseURL
             );
         });
@@ -114,7 +114,7 @@ describe("given a single new connection listening to a base URL", () => {
                 );
                 mockSendData.mockResolvedValue(true);
                 mockClientFactory.createClient.mockReturnValue(mockClient);
-                mockRepository.getKeyphrases.mockResolvedValue(
+                mockRepository.getOccurrences.mockResolvedValue(
                     expectedOccurrences
                 );
                 const domain = new NewConnectionDomain(
@@ -126,8 +126,8 @@ describe("given a single new connection listening to a base URL", () => {
             });
 
             test("calls repository to obtain current keyphrase state for base URL", () => {
-                expect(mockRepository.getKeyphrases).toHaveBeenCalledTimes(1);
-                expect(mockRepository.getKeyphrases).toHaveBeenCalledWith(
+                expect(mockRepository.getOccurrences).toHaveBeenCalledTimes(1);
+                expect(mockRepository.getOccurrences).toHaveBeenCalledWith(
                     connection.baseURL
                 );
             });
@@ -160,7 +160,7 @@ describe("given a single new connection listening to a base URL", () => {
             jest.resetAllMocks();
             jest.spyOn(console, "error").mockImplementation(() => undefined);
             mockClientFactory.createClient.mockReturnValue(mockClient);
-            mockRepository.getKeyphrases.mockRejectedValue(new Error());
+            mockRepository.getOccurrences.mockRejectedValue(new Error());
             const domain = new NewConnectionDomain(
                 mockClientFactory,
                 mockRepository
@@ -190,7 +190,7 @@ describe("given a single new connection listening to a base URL", () => {
             mockClientFactory.createClient.mockImplementation(() => {
                 throw new Error();
             });
-            mockRepository.getKeyphrases.mockResolvedValue(
+            mockRepository.getOccurrences.mockResolvedValue(
                 createOccurrences(BASE_URL, 1)
             );
 
@@ -213,7 +213,7 @@ describe("given a single new connection listening to a base URL", () => {
     test("returns failure if error occurs during the transmission of keyphrases state", async () => {
         jest.resetAllMocks();
         jest.spyOn(console, "error").mockImplementation(() => undefined);
-        mockRepository.getKeyphrases.mockResolvedValue(
+        mockRepository.getOccurrences.mockResolvedValue(
             createOccurrences(BASE_URL, 1)
         );
         mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -233,7 +233,7 @@ describe("given a single new connection listening to a base URL", () => {
 
     test("returns failure if the client fails to send keyphrase state", async () => {
         jest.resetAllMocks();
-        mockRepository.getKeyphrases.mockResolvedValue(
+        mockRepository.getOccurrences.mockResolvedValue(
             createOccurrences(BASE_URL, 1)
         );
         mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -300,7 +300,7 @@ describe.each([
             beforeAll(async () => {
                 jest.resetAllMocks();
                 mockClientFactory.createClient.mockReturnValue(mockClient);
-                mockRepository.getKeyphrases.mockResolvedValue([]);
+                mockRepository.getOccurrences.mockResolvedValue([]);
                 const domain = new NewConnectionDomain(
                     mockClientFactory,
                     mockRepository
@@ -310,10 +310,10 @@ describe.each([
             });
 
             test("calls repository to obtain current keyphrase state for each base URL", () => {
-                expect(mockRepository.getKeyphrases).toHaveBeenCalledTimes(
+                expect(mockRepository.getOccurrences).toHaveBeenCalledTimes(
                     uniqueBaseURLs.length
                 );
-                expect(mockRepository.getKeyphrases.mock.calls.flat()).toEqual(
+                expect(mockRepository.getOccurrences.mock.calls.flat()).toEqual(
                     expect.arrayContaining(uniqueBaseURLs)
                 );
             });
@@ -349,7 +349,7 @@ describe.each([
                 beforeAll(async () => {
                     jest.resetAllMocks();
                     mockClientFactory.createClient.mockReturnValue(mockClient);
-                    mockRepository.getKeyphrases.mockResolvedValue(
+                    mockRepository.getOccurrences.mockResolvedValue(
                         expectedOccurrences
                     );
                     mockSendData = On(mockClient).get(
@@ -367,11 +367,11 @@ describe.each([
                 });
 
                 test("calls repository to obtain current keyphrase state for each base URL", () => {
-                    expect(mockRepository.getKeyphrases).toHaveBeenCalledTimes(
+                    expect(mockRepository.getOccurrences).toHaveBeenCalledTimes(
                         uniqueBaseURLs.length
                     );
                     expect(
-                        mockRepository.getKeyphrases.mock.calls.flat()
+                        mockRepository.getOccurrences.mock.calls.flat()
                     ).toEqual(expect.arrayContaining(uniqueBaseURLs));
                 });
 
@@ -415,7 +415,7 @@ describe.each([
                     () => undefined
                 );
                 mockClientFactory.createClient.mockReturnValue(mockClient);
-                mockRepository.getKeyphrases.mockRejectedValue(new Error());
+                mockRepository.getOccurrences.mockRejectedValue(new Error());
                 const domain = new NewConnectionDomain(
                     mockClientFactory,
                     mockRepository
@@ -448,7 +448,7 @@ describe.each([
                 mockClientFactory.createClient.mockImplementation(() => {
                     throw new Error();
                 });
-                mockRepository.getKeyphrases.mockResolvedValue(
+                mockRepository.getOccurrences.mockResolvedValue(
                     createOccurrences(BASE_URL, 1)
                 );
                 const domain = new NewConnectionDomain(
@@ -474,7 +474,7 @@ describe.each([
         test("returns all IDs if error occurs during the transmission of keyphrases state to all connections", async () => {
             jest.resetAllMocks();
             jest.spyOn(console, "error").mockImplementation(() => undefined);
-            mockRepository.getKeyphrases.mockResolvedValue(
+            mockRepository.getOccurrences.mockResolvedValue(
                 createOccurrences(BASE_URL, 1)
             );
             mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -497,7 +497,7 @@ describe.each([
 
         test("returns all IDs if the client fails to send keyphrase state to all connections", async () => {
             jest.resetAllMocks();
-            mockRepository.getKeyphrases.mockResolvedValue(
+            mockRepository.getOccurrences.mockResolvedValue(
                 createOccurrences(BASE_URL, 1)
             );
             mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -520,7 +520,7 @@ describe.each([
 
         test("returns first ID if the client only fails to send keyphrase for first connection", async () => {
             jest.resetAllMocks();
-            mockRepository.getKeyphrases.mockResolvedValue(
+            mockRepository.getOccurrences.mockResolvedValue(
                 createOccurrences(BASE_URL, 1)
             );
             mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -556,7 +556,9 @@ describe("given duplicate connections", () => {
         beforeAll(async () => {
             jest.resetAllMocks();
             mockClientFactory.createClient.mockReturnValue(mockClient);
-            mockRepository.getKeyphrases.mockResolvedValue(expectedOccurrences);
+            mockRepository.getOccurrences.mockResolvedValue(
+                expectedOccurrences
+            );
             mockSendData = On(mockClient).get(method((mock) => mock.sendData));
             mockSendData.mockResolvedValue(true);
             const domain = new NewConnectionDomain(
@@ -568,8 +570,10 @@ describe("given duplicate connections", () => {
         });
 
         test("calls repository once to obtain current keyphrase state", () => {
-            expect(mockRepository.getKeyphrases).toHaveBeenCalledTimes(1);
-            expect(mockRepository.getKeyphrases).toHaveBeenCalledWith(BASE_URL);
+            expect(mockRepository.getOccurrences).toHaveBeenCalledTimes(1);
+            expect(mockRepository.getOccurrences).toHaveBeenCalledWith(
+                BASE_URL
+            );
         });
 
         test("calls the web socket client factory to create a client once", () => {
@@ -596,7 +600,7 @@ describe("given duplicate connections", () => {
         jest.resetAllMocks();
         jest.spyOn(console, "error").mockImplementation(() => undefined);
         mockClientFactory.createClient.mockReturnValue(mockClient);
-        mockRepository.getKeyphrases.mockRejectedValue(new Error());
+        mockRepository.getOccurrences.mockRejectedValue(new Error());
         const domain = new NewConnectionDomain(
             mockClientFactory,
             mockRepository
@@ -613,7 +617,7 @@ describe("given duplicate connections", () => {
         mockClientFactory.createClient.mockImplementation(() => {
             throw new Error();
         });
-        mockRepository.getKeyphrases.mockResolvedValue(
+        mockRepository.getOccurrences.mockResolvedValue(
             createOccurrences(BASE_URL, 1)
         );
         const domain = new NewConnectionDomain(
@@ -630,7 +634,7 @@ describe("given duplicate connections", () => {
     test("returns one failure ID if error occurs during the transmission of keyphrases state", async () => {
         jest.resetAllMocks();
         jest.spyOn(console, "error").mockImplementation(() => undefined);
-        mockRepository.getKeyphrases.mockResolvedValue(
+        mockRepository.getOccurrences.mockResolvedValue(
             createOccurrences(BASE_URL, 1)
         );
         mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -651,7 +655,7 @@ describe("given duplicate connections", () => {
 
     test("returns one failure ID if the client fails to send keyphrase state", async () => {
         jest.resetAllMocks();
-        mockRepository.getKeyphrases.mockResolvedValue(
+        mockRepository.getOccurrences.mockResolvedValue(
             createOccurrences(BASE_URL, 1)
         );
         mockClientFactory.createClient.mockReturnValue(mockClient);
@@ -677,7 +681,7 @@ test("sends keyphrases in chunks of 100 if more than 100 keyphrases are stored",
     const expectedSecondChunk = createOccurrences(BASE_URL, 100);
     const expectedThirdChunk = createOccurrences(BASE_URL, 1);
     const connection = createConnection(CONNECTION_ID, CALLBACK_URL, BASE_URL);
-    mockRepository.getKeyphrases.mockResolvedValue([
+    mockRepository.getOccurrences.mockResolvedValue([
         ...expectedFirstChunk,
         ...expectedSecondChunk,
         ...expectedThirdChunk,

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -80,6 +80,7 @@ class KeyphraseRepository implements Repository {
                 pathname: splitSK[0],
                 keyphrase: splitSK[1],
                 occurrences: document.Occurrences,
+                aggregated: document.Aggregated,
             };
         });
     }
@@ -222,6 +223,7 @@ class KeyphraseRepository implements Repository {
             pk: baseURL,
             sk: `${pathname}#${occurrence.keyphrase}`,
             Occurrences: occurrence.occurrences,
+            Aggregated: false,
         };
     }
 

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -72,24 +72,33 @@ class KeyphraseRepository implements Repository {
         }
     }
 
-    async getKeyphrases(baseURL: string): Promise<PathnameOccurrences[]> {
-        const documents = await this.queryKeyphrases(baseURL);
-        return documents.map((document) => {
-            const splitSK = document.sk.split("#");
-            return {
-                pathname: splitSK[0],
-                keyphrase: splitSK[1],
-                occurrences: document.Occurrences,
-                aggregated: document.Aggregated,
-            };
-        });
-    }
-
-    async getPathKeyphrases(
+    getKeyphrases(
         baseURL: string,
         pathname: string
-    ): Promise<KeyphraseOccurrences[]> {
-        const documents = await this.queryKeyphrases(baseURL, `${pathname}#`);
+    ): Promise<KeyphraseOccurrences[]>;
+    getKeyphrases(baseURL: string): Promise<PathnameOccurrences[]>;
+
+    async getKeyphrases(
+        baseURL: string,
+        pathname?: string
+    ): Promise<KeyphraseOccurrences[] | PathnameOccurrences[]> {
+        const documents = await this.queryKeyphrases(
+            baseURL,
+            pathname ? `${pathname}#` : undefined
+        );
+
+        if (!pathname) {
+            return documents.map((document) => {
+                const splitSK = document.sk.split("#");
+                return {
+                    pathname: splitSK[0],
+                    keyphrase: splitSK[1],
+                    occurrences: document.Occurrences,
+                    aggregated: document.Aggregated,
+                };
+            });
+        }
+
         return documents.map((document) => {
             const splitSK = document.sk.split("#");
             return {

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -95,6 +95,7 @@ class KeyphraseRepository implements Repository {
             return {
                 keyphrase: splitSK[1],
                 occurrences: document.Occurrences,
+                aggregated: document.Aggregated,
             };
         });
     }

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -373,7 +373,7 @@ class KeyphraseRepository implements Repository {
         } catch (ex) {
             if (
                 this.isTransactionCancelledException(ex) &&
-                ex.CancellationReasons[2].Code == "ConditionalCheckFailed"
+                ex.CancellationReasons[2]?.Code == "ConditionalCheckFailed"
             ) {
                 return true;
             }

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -8,13 +8,44 @@ process.env.AWS_REGION = "eu-west-2";
 
 import dynamoose from "dynamoose";
 
-import { KeyphraseOccurrences } from "../../ports/Repository";
+import {
+    KeyphraseOccurrences,
+    SiteKeyphraseOccurrences,
+} from "../../ports/Repository";
 import KeyphraseRepository from "../KeyphraseRepository";
 
 const dynamoDB = new dynamoose.aws.ddb.DynamoDB({
     endpoint: "http://localhost:8000",
 });
 dynamoose.aws.ddb.set(dynamoDB);
+
+function createSiteOccurrence(
+    url: URL,
+    keyphraseOccurrence: KeyphraseOccurrences
+): SiteKeyphraseOccurrences {
+    return {
+        baseURL: url.hostname,
+        pathname: url.pathname,
+        keyphrase: keyphraseOccurrence.keyphrase,
+        occurrences: keyphraseOccurrence.occurrences,
+    };
+}
+
+function createRandomSiteOccurrences(
+    url: URL,
+    numberToCreate: number
+): SiteKeyphraseOccurrences[] {
+    const result: SiteKeyphraseOccurrences[] = [];
+    for (let i = 1; i <= numberToCreate; i++) {
+        const occurrence = createSiteOccurrence(
+            url,
+            createKeyphraseOccurrence(`test-${i}`, i)
+        );
+        result.push(occurrence);
+    }
+
+    return result;
+}
 
 function createKeyphraseOccurrence(
     keyphrase: string,
@@ -38,9 +69,34 @@ function createRandomOccurrences(
     return result;
 }
 
+function extractKeyphraseOccurrence(
+    siteOccurrence: SiteKeyphraseOccurrences
+): KeyphraseOccurrences;
+function extractKeyphraseOccurrence(
+    siteOccurrence: SiteKeyphraseOccurrences[]
+): KeyphraseOccurrences[];
+function extractKeyphraseOccurrence(
+    siteOccurrence: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
+): KeyphraseOccurrences | KeyphraseOccurrences[] {
+    if (Array.isArray(siteOccurrence)) {
+        return siteOccurrence.map((current) => ({
+            keyphrase: current.keyphrase,
+            occurrences: current.occurrences,
+            aggregated: current.aggregated,
+        }));
+    }
+
+    return {
+        keyphrase: siteOccurrence.keyphrase,
+        occurrences: siteOccurrence.occurrences,
+        aggregated: siteOccurrence.aggregated,
+    };
+}
+
 const TABLE_NAME = "keyphrase-table";
 const VALID_URL = new URL("http://www.example.com/example");
 const OTHER_URL = new URL("http://www.test.com/test");
+
 const TEST_KEYPHRASES = [
     createKeyphraseOccurrence("test", 5),
     createKeyphraseOccurrence("wibble", 3),
@@ -55,18 +111,29 @@ beforeAll(() => {
 });
 
 describe("GET TOTAL: Only returns totals related to provided base URL", () => {
-    const expectedTotal = TEST_KEYPHRASES[0];
+    const expectedTotal = createSiteOccurrence(
+        VALID_URL,
+        createKeyphraseOccurrence("sphere", 3)
+    );
 
     beforeAll(async () => {
-        await repository.addTotals(VALID_URL.hostname, expectedTotal);
-        await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
+        await repository.addOccurrencesToTotals(expectedTotal);
+        await repository.addOccurrencesToTotals(
+            createSiteOccurrence(
+                OTHER_URL,
+                createKeyphraseOccurrence("dyson", 2)
+            )
+        );
     });
 
     test("get returns only totals associated with provied base URL", async () => {
         const response = await repository.getTotals(VALID_URL.hostname);
 
         expect(response).toHaveLength(1);
-        expect(response[0]).toEqual(expectedTotal);
+        expect(response[0]).toEqual({
+            keyphrase: expectedTotal.keyphrase,
+            occurrences: expectedTotal.occurrences,
+        });
     });
 
     afterAll(async () => {
@@ -76,16 +143,17 @@ describe("GET TOTAL: Only returns totals related to provided base URL", () => {
 
 describe.each([
     ["no sites", []],
-    ["one site", [VALID_URL.hostname]],
-    ["multiple sites", [VALID_URL.hostname, OTHER_URL.hostname]],
+    ["one site", [VALID_URL]],
+    ["multiple sites", [VALID_URL, OTHER_URL]],
 ])(
     "GET USAGES: given keyphrase used on %s",
-    (message: string, sites: string[]) => {
+    (message: string, sites: URL[]) => {
         const expectedKeyphrase = TEST_KEYPHRASES[0];
 
         beforeAll(async () => {
             for (const site of sites) {
-                await repository.addTotals(site, expectedKeyphrase);
+                const total = createSiteOccurrence(site, expectedKeyphrase);
+                await repository.addOccurrencesToTotals(total);
             }
         });
 
@@ -95,7 +163,7 @@ describe.each([
             );
 
             expect(response).toHaveLength(sites.length);
-            expect(response).toEqual(sites);
+            expect(response).toEqual(sites.map((site) => site.hostname));
         });
 
         afterAll(async () => {
@@ -105,21 +173,28 @@ describe.each([
 );
 
 describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
-    const expectedKeyphrase = TEST_KEYPHRASES[0];
-    const expectedSite = VALID_URL.hostname;
+    const expectedKeyphrase = "sphere";
 
     beforeAll(async () => {
-        await repository.addTotals(expectedSite, expectedKeyphrase);
-        await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[1]);
+        await repository.addOccurrencesToTotals(
+            createSiteOccurrence(
+                VALID_URL,
+                createKeyphraseOccurrence(expectedKeyphrase, 2)
+            )
+        );
+        await repository.addOccurrencesToTotals(
+            createSiteOccurrence(
+                OTHER_URL,
+                createKeyphraseOccurrence("wibble", 2)
+            )
+        );
     });
 
     test("get returns only totals associated with provided base URL", async () => {
-        const response = await repository.getKeyphraseUsages(
-            expectedKeyphrase.keyphrase
-        );
+        const response = await repository.getKeyphraseUsages(expectedKeyphrase);
 
         expect(response).toHaveLength(1);
-        expect(response[0]).toEqual(expectedSite);
+        expect(response[0]).toEqual(VALID_URL.hostname);
     });
 
     afterAll(async () => {
@@ -430,36 +505,47 @@ describe("keyphrase occurrence storage", () => {
 });
 
 describe("total handling", () => {
+    const TEST_SITE_OCCURRENCES = createRandomSiteOccurrences(VALID_URL, 1);
+    const TEST_BATCH_SITE_OCCURRENCES = createRandomSiteOccurrences(
+        VALID_URL,
+        26
+    );
+
     beforeEach(async () => {
         await repository.empty();
     });
 
     describe.each([
-        ["a single total", TEST_KEYPHRASES[0], [TEST_KEYPHRASES[0]]],
-        ["less than 25 totals", TEST_KEYPHRASES, TEST_KEYPHRASES],
         [
-            "greater than 25 totals",
-            TEST_BATCH_KEYPHRASES,
-            TEST_BATCH_KEYPHRASES,
+            "a single item",
+            TEST_SITE_OCCURRENCES[0],
+            [extractKeyphraseOccurrence(TEST_SITE_OCCURRENCES[0])],
+        ],
+        [
+            "less than 25 items",
+            TEST_BATCH_SITE_OCCURRENCES,
+            extractKeyphraseOccurrence(TEST_BATCH_SITE_OCCURRENCES),
+        ],
+        [
+            "greater than 25 items",
+            TEST_BATCH_SITE_OCCURRENCES,
+            extractKeyphraseOccurrence(TEST_BATCH_SITE_OCCURRENCES),
         ],
     ])(
         "new total storage given %s",
         (
             message: string,
-            input: KeyphraseOccurrences | KeyphraseOccurrences[],
+            input: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[],
             expected: KeyphraseOccurrences[]
         ) => {
             test("returns success when total storage succeeds", async () => {
-                const actual = await repository.addTotals(
-                    VALID_URL.hostname,
-                    input
-                );
+                const actual = await repository.addOccurrencesToTotals(input);
 
                 expect(actual).toBe(true);
             });
 
             test("stores site totals successfully", async () => {
-                await repository.addTotals(VALID_URL.hostname, input);
+                await repository.addOccurrencesToTotals(input);
 
                 const stored = await repository.getTotals(VALID_URL.hostname);
 
@@ -467,7 +553,7 @@ describe("total handling", () => {
             });
 
             test("stores global total successfully", async () => {
-                await repository.addTotals(VALID_URL.hostname, input);
+                await repository.addOccurrencesToTotals(input);
 
                 const stored = await repository.getTotals();
 
@@ -477,84 +563,89 @@ describe("total handling", () => {
     );
 
     test.each([
-        ["a single total", TEST_KEYPHRASES[0]],
-        ["multiple totals", TEST_KEYPHRASES],
+        ["a single item", TEST_SITE_OCCURRENCES[0]],
+        ["multiple items", TEST_SITE_OCCURRENCES],
     ])(
-        "returns success when total storage succeeds given %s that have been stored before",
+        "returns success when total storage succeeds given %s that have been totalled before",
         async (
             message: string,
-            totals: KeyphraseOccurrences | KeyphraseOccurrences[]
+            items: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
         ) => {
-            await repository.addTotals(VALID_URL.hostname, totals);
+            await repository.addOccurrencesToTotals(items);
 
-            const actual = await repository.addTotals(
-                VALID_URL.hostname,
-                totals
-            );
+            const actual = await repository.addOccurrencesToTotals(items);
 
             expect(actual).toBe(true);
         }
     );
 
     describe("existing total storage", () => {
-        test("increments site total given existing site total", async () => {
-            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
+        test("increments site total given item that has been previously added to total", async () => {
+            await repository.addOccurrencesToTotals(TEST_SITE_OCCURRENCES[0]);
 
-            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
+            await repository.addOccurrencesToTotals(TEST_SITE_OCCURRENCES[0]);
             const stored = await repository.getTotals(VALID_URL.hostname);
 
             expect(stored).toHaveLength(1);
             expect(stored[0]).toEqual({
-                keyphrase: TEST_KEYPHRASES[0].keyphrase,
-                occurrences: TEST_KEYPHRASES[0].occurrences * 2,
+                keyphrase: TEST_SITE_OCCURRENCES[0].keyphrase,
+                occurrences: TEST_SITE_OCCURRENCES[0].occurrences * 2,
             });
         });
 
         test("increments site totals given existing site totals", async () => {
-            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
+            await repository.addOccurrencesToTotals(TEST_SITE_OCCURRENCES);
 
-            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
+            await repository.addOccurrencesToTotals(TEST_SITE_OCCURRENCES);
             const stored = await repository.getTotals(VALID_URL.hostname);
 
-            expect(stored).toHaveLength(2);
-            expect(stored[0]).toEqual({
-                keyphrase: TEST_KEYPHRASES[0].keyphrase,
-                occurrences: TEST_KEYPHRASES[0].occurrences * 2,
-            });
-            expect(stored[1]).toEqual({
-                keyphrase: TEST_KEYPHRASES[1].keyphrase,
-                occurrences: TEST_KEYPHRASES[1].occurrences * 2,
-            });
+            expect(stored).toHaveLength(TEST_SITE_OCCURRENCES.length);
+            for (const expected of TEST_SITE_OCCURRENCES) {
+                expect(stored).toContainEqual({
+                    keyphrase: expected.keyphrase,
+                    occurrences: expected.occurrences * 2,
+                });
+            }
         });
 
         test("increments existing global keyphrase total given a new occurrence on a different base URL", async () => {
-            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES[0]);
+            const commonKeyphrase = createKeyphraseOccurrence("test", 15);
+            await repository.addOccurrencesToTotals(
+                createSiteOccurrence(VALID_URL, commonKeyphrase)
+            );
 
-            await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES[0]);
+            await repository.addOccurrencesToTotals(
+                createSiteOccurrence(OTHER_URL, commonKeyphrase)
+            );
             const stored = await repository.getTotals();
 
             expect(stored).toHaveLength(1);
             expect(stored[0]).toEqual({
-                keyphrase: TEST_KEYPHRASES[0].keyphrase,
-                occurrences: TEST_KEYPHRASES[0].occurrences * 2,
+                keyphrase: commonKeyphrase.keyphrase,
+                occurrences: commonKeyphrase.occurrences * 2,
             });
         });
 
         test("increments existing global keyphrase totals given new occurrences on a different base URL", async () => {
-            await repository.addTotals(VALID_URL.hostname, TEST_KEYPHRASES);
+            const firstSiteOccurrences = TEST_KEYPHRASES.map((current) =>
+                createSiteOccurrence(VALID_URL, current)
+            );
+            const secondSiteOccurrences = TEST_KEYPHRASES.map((current) =>
+                createSiteOccurrence(OTHER_URL, current)
+            );
 
-            await repository.addTotals(OTHER_URL.hostname, TEST_KEYPHRASES);
+            await repository.addOccurrencesToTotals(firstSiteOccurrences);
+
+            await repository.addOccurrencesToTotals(secondSiteOccurrences);
             const stored = await repository.getTotals();
 
-            expect(stored).toHaveLength(2);
-            expect(stored[0]).toEqual({
-                keyphrase: TEST_KEYPHRASES[0].keyphrase,
-                occurrences: TEST_KEYPHRASES[0].occurrences * 2,
-            });
-            expect(stored[1]).toEqual({
-                keyphrase: TEST_KEYPHRASES[1].keyphrase,
-                occurrences: TEST_KEYPHRASES[1].occurrences * 2,
-            });
+            expect(stored).toHaveLength(TEST_KEYPHRASES.length);
+            for (const expected of TEST_KEYPHRASES) {
+                expect(stored).toContainEqual({
+                    keyphrase: expected.keyphrase,
+                    occurrences: expected.occurrences * 2,
+                });
+            }
         });
     });
 
@@ -564,9 +655,8 @@ describe("total handling", () => {
             throw new Error("test error");
         });
 
-        const actual = await repository.addTotals(
-            VALID_URL.hostname,
-            TEST_KEYPHRASES[0]
+        const actual = await repository.addOccurrencesToTotals(
+            TEST_SITE_OCCURRENCES[0]
         );
         putItemSpy.mockRestore();
 
@@ -579,9 +669,8 @@ describe("total handling", () => {
             throw new Error("test error");
         });
 
-        const actual = await repository.addTotals(
-            VALID_URL.hostname,
-            TEST_KEYPHRASES
+        const actual = await repository.addOccurrencesToTotals(
+            TEST_SITE_OCCURRENCES
         );
         putItemSpy.mockRestore();
 
@@ -651,17 +740,17 @@ describe("empty table behaviour", () => {
     );
 
     describe.each([
-        ["a single total", TEST_KEYPHRASES[0]],
-        ["less than 25 totals", TEST_KEYPHRASES],
-        ["more than 25 totals", TEST_BATCH_KEYPHRASES],
+        ["a single total", createRandomSiteOccurrences(VALID_URL, 1)[0]],
+        ["less than 25 totals", createRandomSiteOccurrences(VALID_URL, 24)],
+        ["more than 25 totals", createRandomSiteOccurrences(VALID_URL, 26)],
     ])(
         "Empty clears all totals given %s stored",
         (
             message: string,
-            occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
+            occurrences: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
         ) => {
             beforeEach(async () => {
-                await repository.addTotals(VALID_URL.hostname, occurrences);
+                await repository.addOccurrencesToTotals(occurrences);
             });
 
             test("returns success", async () => {

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -145,7 +145,7 @@ describe("path keyphrase occurrence retrieval", () => {
                 input
             );
 
-            const stored = await repository.getPathKeyphrases(
+            const stored = await repository.getKeyphrases(
                 VALID_URL.hostname,
                 VALID_URL.pathname
             );
@@ -170,7 +170,7 @@ describe("path keyphrase occurrence retrieval", () => {
             TEST_KEYPHRASES[1]
         );
 
-        const stored = await repository.getPathKeyphrases(
+        const stored = await repository.getKeyphrases(
             VALID_URL.hostname,
             VALID_URL.pathname
         );
@@ -191,7 +191,7 @@ describe("path keyphrase occurrence retrieval", () => {
             TEST_KEYPHRASES[1]
         );
 
-        const stored = await repository.getPathKeyphrases(
+        const stored = await repository.getKeyphrases(
             VALID_URL.hostname,
             VALID_URL.pathname
         );

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -127,6 +127,43 @@ describe("GET USAGE: Only returns usages related to provided keyphrase", () => {
     });
 });
 
+describe("individual keyphrase occurrence retrieval", () => {
+    beforeEach(async () => {
+        await repository.empty();
+    });
+
+    test("returns undefined if no occurrences stored for keyphrase", async () => {
+        const actual = await repository.getOccurrences(
+            VALID_URL.hostname,
+            VALID_URL.pathname,
+            TEST_KEYPHRASES[0].keyphrase
+        );
+
+        expect(actual).toBeUndefined();
+    });
+
+    test("returns occurrence if occurrences stored for provided keyphrase on site", async () => {
+        const expected = TEST_KEYPHRASES[0];
+        await repository.storeKeyphrases(
+            VALID_URL.hostname,
+            VALID_URL.pathname,
+            expected
+        );
+
+        const actual = await repository.getOccurrences(
+            VALID_URL.hostname,
+            VALID_URL.pathname,
+            expected.keyphrase
+        );
+
+        expect(actual).toEqual({ ...expected, aggregated: false });
+    });
+
+    afterEach(async () => {
+        await repository.empty();
+    });
+});
+
 describe("path keyphrase occurrence retrieval", () => {
     beforeEach(async () => {
         await repository.empty();
@@ -145,7 +182,7 @@ describe("path keyphrase occurrence retrieval", () => {
                 input
             );
 
-            const stored = await repository.getKeyphrases(
+            const stored = await repository.getOccurrences(
                 VALID_URL.hostname,
                 VALID_URL.pathname
             );
@@ -170,7 +207,7 @@ describe("path keyphrase occurrence retrieval", () => {
             TEST_KEYPHRASES[1]
         );
 
-        const stored = await repository.getKeyphrases(
+        const stored = await repository.getOccurrences(
             VALID_URL.hostname,
             VALID_URL.pathname
         );
@@ -191,7 +228,7 @@ describe("path keyphrase occurrence retrieval", () => {
             TEST_KEYPHRASES[1]
         );
 
-        const stored = await repository.getKeyphrases(
+        const stored = await repository.getOccurrences(
             VALID_URL.hostname,
             VALID_URL.pathname
         );
@@ -211,7 +248,7 @@ describe("site keyphrase occurrence retrieval", () => {
     });
 
     test("returns no keyphrase occurrences given none stored for site", async () => {
-        const stored = await repository.getKeyphrases(VALID_URL.hostname);
+        const stored = await repository.getOccurrences(VALID_URL.hostname);
 
         expect(stored).toHaveLength(0);
     });
@@ -229,7 +266,7 @@ describe("site keyphrase occurrence retrieval", () => {
             TEST_KEYPHRASES[1]
         );
 
-        const response = await repository.getKeyphrases(VALID_URL.hostname);
+        const response = await repository.getOccurrences(VALID_URL.hostname);
 
         expect(response).toHaveLength(2);
         expect(response).toContainEqual({
@@ -259,7 +296,7 @@ describe("site keyphrase occurrence retrieval", () => {
             TEST_KEYPHRASES[1]
         );
 
-        const response = await repository.getKeyphrases(VALID_URL.hostname);
+        const response = await repository.getOccurrences(VALID_URL.hostname);
 
         expect(response).toHaveLength(1);
         expect(response[0]).toEqual({
@@ -312,7 +349,7 @@ describe("keyphrase occurrence storage", () => {
                     input
                 );
 
-                const stored = await repository.getKeyphrases(
+                const stored = await repository.getOccurrences(
                     VALID_URL.hostname
                 );
 
@@ -346,7 +383,7 @@ describe("keyphrase occurrence storage", () => {
                 VALID_URL.pathname,
                 newValue
             );
-            const stored = await repository.getKeyphrases(VALID_URL.hostname);
+            const stored = await repository.getOccurrences(VALID_URL.hostname);
 
             expect(stored).toHaveLength(1);
             expect(stored[0]).toEqual({
@@ -373,7 +410,7 @@ describe("keyphrase occurrence storage", () => {
                 VALID_URL.pathname,
                 newValues
             );
-            const stored = await repository.getKeyphrases(VALID_URL.hostname);
+            const stored = await repository.getOccurrences(VALID_URL.hostname);
 
             expect(stored).toHaveLength(newValues.length);
             for (const occurrence of newValues) {
@@ -604,7 +641,7 @@ describe("empty table behaviour", () => {
 
             test("empties table of occurrences", async () => {
                 await repository.empty();
-                const actual = await repository.getKeyphrases(
+                const actual = await repository.getOccurrences(
                     VALID_URL.hostname
                 );
 

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -138,11 +138,11 @@ describe("path keyphrase occurrence retrieval", () => {
         ["multiple occurrences stored for path", TEST_KEYPHRASES],
     ])(
         "returns stored occurrences for path given %s",
-        async (message: string, expected: KeyphraseOccurrences[]) => {
+        async (message: string, input: KeyphraseOccurrences[]) => {
             await repository.storeKeyphrases(
                 VALID_URL.hostname,
                 VALID_URL.pathname,
-                expected
+                input
             );
 
             const stored = await repository.getPathKeyphrases(
@@ -150,6 +150,9 @@ describe("path keyphrase occurrence retrieval", () => {
                 VALID_URL.pathname
             );
 
+            const expected = input.map((occurrence) => {
+                return { ...occurrence, aggregated: false };
+            });
             expect(stored).toEqual(expected);
         }
     );
@@ -173,7 +176,7 @@ describe("path keyphrase occurrence retrieval", () => {
         );
 
         expect(stored).toHaveLength(1);
-        expect(stored[0]).toEqual(TEST_KEYPHRASES[0]);
+        expect(stored[0]).toEqual({ ...TEST_KEYPHRASES[0], aggregated: false });
     });
 
     test("only returns occurrences related to provided path and site given occurrences on same path on another site", async () => {
@@ -194,7 +197,7 @@ describe("path keyphrase occurrence retrieval", () => {
         );
 
         expect(stored).toHaveLength(1);
-        expect(stored[0]).toEqual(TEST_KEYPHRASES[0]);
+        expect(stored[0]).toEqual({ ...TEST_KEYPHRASES[0], aggregated: false });
     });
 
     afterEach(async () => {

--- a/services/keyphrase/libs/keyphrase-repository-library/enums/KeyphraseTableFields.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/enums/KeyphraseTableFields.ts
@@ -6,6 +6,7 @@ enum KeyphraseTableKeyFields {
 
 enum KeyphraseTableNonKeyFields {
     Occurrences = "Occurrences",
+    Aggregated = "Aggregated",
 }
 
 export { KeyphraseTableKeyFields, KeyphraseTableNonKeyFields };

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -1,10 +1,12 @@
-type PathnameOccurrences = {
+type SiteKeyphraseOccurrences = {
+    baseURL: string;
     pathname: string;
     keyphrase: string;
     occurrences: number;
     aggregated?: boolean;
 };
 
+type PathnameOccurrences = Omit<SiteKeyphraseOccurrences, "baseURL">;
 type KeyphraseOccurrences = Omit<PathnameOccurrences, "pathname">;
 
 interface Repository {
@@ -25,11 +27,15 @@ interface Repository {
         occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
     ): Promise<boolean>;
     getTotals(baseURL?: string): Promise<KeyphraseOccurrences[]>;
-    addTotals(
-        baseURL: string,
-        totals: KeyphraseOccurrences | KeyphraseOccurrences[]
+    addOccurrencesToTotals(
+        occurrences: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
     ): Promise<boolean>;
     getKeyphraseUsages(keyphrase: string): Promise<string[]>;
 }
 
-export { KeyphraseOccurrences, PathnameOccurrences, Repository };
+export {
+    KeyphraseOccurrences,
+    PathnameOccurrences,
+    Repository,
+    SiteKeyphraseOccurrences,
+};

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -9,11 +9,11 @@ type KeyphraseOccurrences = Omit<PathnameOccurrences, "pathname">;
 
 interface Repository {
     empty(): Promise<boolean>;
-    getKeyphrases(baseURL: string): Promise<PathnameOccurrences[]>;
-    getPathKeyphrases(
+    getKeyphrases(
         baseURL: string,
         pathname: string
     ): Promise<KeyphraseOccurrences[]>;
+    getKeyphrases(baseURL: string): Promise<PathnameOccurrences[]>;
     storeKeyphrases(
         baseURL: string,
         pathname: string,

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -1,13 +1,11 @@
-type KeyphraseOccurrences = {
-    keyphrase: string;
-    occurrences: number;
-};
-
 type PathnameOccurrences = {
     pathname: string;
     keyphrase: string;
     occurrences: number;
+    aggregated?: boolean;
 };
+
+type KeyphraseOccurrences = Omit<PathnameOccurrences, "pathname">;
 
 interface Repository {
     empty(): Promise<boolean>;

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -9,11 +9,16 @@ type KeyphraseOccurrences = Omit<PathnameOccurrences, "pathname">;
 
 interface Repository {
     empty(): Promise<boolean>;
-    getKeyphrases(
+    getOccurrences(
+        baseURL: string,
+        pathname: string,
+        keyphrase: string
+    ): Promise<KeyphraseOccurrences | undefined>;
+    getOccurrences(
         baseURL: string,
         pathname: string
     ): Promise<KeyphraseOccurrences[]>;
-    getKeyphrases(baseURL: string): Promise<PathnameOccurrences[]>;
+    getOccurrences(baseURL: string): Promise<PathnameOccurrences[]>;
     storeKeyphrases(
         baseURL: string,
         pathname: string,

--- a/services/keyphrase/libs/keyphrase-repository-library/schemas/KeyphraseTableOccurrenceItem.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/schemas/KeyphraseTableOccurrenceItem.ts
@@ -9,6 +9,7 @@ class KeyphraseTableOccurrenceItem extends Item {
     [KeyphraseTableKeyFields.HashKey]!: string;
     [KeyphraseTableKeyFields.RangeKey]!: string;
     [KeyphraseTableNonKeyFields.Occurrences]!: number;
+    [KeyphraseTableNonKeyFields.Aggregated]!: boolean | undefined;
 }
 
 export default KeyphraseTableOccurrenceItem;

--- a/services/keyphrase/libs/keyphrase-repository-library/schemas/KeyphraseTableOccurrenceSchema.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/schemas/KeyphraseTableOccurrenceSchema.ts
@@ -18,6 +18,9 @@ const schema = new Schema({
         type: Number,
         required: true,
     },
+    [KeyphraseTableNonKeyFields.Aggregated]: {
+        type: Boolean,
+    },
 });
 
 export default schema;


### PR DESCRIPTION
Resolves #265 

# What

Updated KeyphraseRepository to:
- Enable retrieval of individual keyphrase occurrences using base URL, pathname, and keyphrase
- Only update the totals for a given keyphrase if the corresponding keyphrase occurrence has not been added to the total
    - Uses a new "Aggregated" flag on each keyphrase occurrence which indicates whether that occurrence has been added to site/global totals
    - Once added, set to true
    - Upon update, the flag is reset to false to allow total changes to be made.

# Why

To prevent occurrences from being added to site and global totals more than once