### PR TITLE
Feature/improve waiting message

### DIFF
--- a/ui/src/components/KeyphraseCloud.tsx
+++ b/ui/src/components/KeyphraseCloud.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from "react";
 import { WordCloud, WordCloudConfig } from "@ant-design/plots";
+import { Empty } from "antd";
 
 type KeyphraseCloudProps = {
     occurrences: Record<string, number>;
@@ -21,7 +22,9 @@ function KeyphraseCloud(props: KeyphraseCloudProps) {
 
     return (
         <Fragment>
-            {occurrences.length == 0 && <p>Awaiting results...</p>}
+            {occurrences.length == 0 && (
+                <Empty description={<span>Awaiting results...</span>} />
+            )}
             {occurrences.length != 0 && (
                 <figure>
                     <WordCloud {...config} />

--- a/ui/src/components/Results.tsx
+++ b/ui/src/components/Results.tsx
@@ -146,7 +146,7 @@ function Results(props: ResultsProps) {
                     <KeyphraseCloud occurrences={totals} />
                 </Col>
             </Row>
-            <Row>
+            <Row style={{ marginTop: "5px" }}>
                 <Col span={24}>
                     <Table
                         columns={columns}

--- a/ui/src/components/Results.tsx
+++ b/ui/src/components/Results.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useState, ReactNode } from "react";
 import { Link, Navigate, useParams } from "react-router-dom";
-import { Button, Col, Row, Table, Typography } from "antd";
+import { Button, Col, Row, Table, Typography, Empty } from "antd";
 import type { ColumnsType } from "antd/es/table";
 
 import { PathnameOccurrences } from "../clients/interfaces/KeyphraseServiceClient";
@@ -148,14 +148,20 @@ function Results(props: ResultsProps) {
             </Row>
             <Row>
                 <Col span={24}>
-                    {groupedResults.length == 0 && <p>Awaiting results...</p>}
-                    {groupedResults.length != 0 && (
-                        <Table
-                            columns={columns}
-                            dataSource={groupedResults}
-                            pagination={false}
-                        />
-                    )}
+                    <Table
+                        columns={columns}
+                        dataSource={groupedResults}
+                        pagination={false}
+                        locale={{
+                            emptyText: (
+                                <Empty
+                                    description={
+                                        <span>Awaiting results...</span>
+                                    }
+                                />
+                            ),
+                        }}
+                    />
                 </Col>
             </Row>
         </Fragment>

--- a/ui/src/components/__tests__/Results.test.tsx
+++ b/ui/src/components/__tests__/Results.test.tsx
@@ -280,8 +280,8 @@ describe("given valid encoded url", () => {
                 );
             });
 
-            test("does not render table to display results", async () => {
-                const { queryByRole } = renderWithRouter(
+            test("does not render any of the occurrences", async () => {
+                const { getByText, getByRole } = renderWithRouter(
                     <Results
                         keyphraseServiceClientFactory={
                             mockKeyphraseClientFactory
@@ -289,10 +289,30 @@ describe("given valid encoded url", () => {
                     />,
                     encodeURIComponent(VALID_URL)
                 );
-
                 await waitFor(() =>
-                    expect(queryByRole("table")).not.toBeInTheDocument()
+                    expect(
+                        getByText(AWAITING_RESULTS_MESSAGE)
+                    ).toBeInTheDocument()
                 );
+                const table = getByRole("table");
+
+                for (const occurrence of occurrences) {
+                    expect(
+                        within(table).queryByRole("cell", {
+                            name: occurrence.keyphrase,
+                        })
+                    ).not.toBeInTheDocument();
+                    expect(
+                        within(table).queryByRole("cell", {
+                            name: occurrence.pathname,
+                        })
+                    ).not.toBeInTheDocument();
+                    expect(
+                        within(table).queryByRole("cell", {
+                            name: occurrence.occurrences.toString(),
+                        })
+                    ).not.toBeInTheDocument();
+                }
             });
         }
     );


### PR DESCRIPTION
# What 

Updated results page to show empty image when no results have been received yet

# Why

To improve the visual appearance of the page while the user is awaiting results