### PR TITLE
Feature/project occurrences top usages

### DIFF
--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -93,7 +93,9 @@ Resources:
                       - AttributeName: pk
                         KeyType: RANGE
                   Projection:
-                      ProjectionType: KEYS_ONLY
+                      ProjectionType: INCLUDE
+                      NonKeyAttributes:
+                          - Occurrences
     ParsedContentBucket:
         Type: AWS::S3::Bucket
         Properties:

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -712,3 +712,7 @@ Resources:
             Environment:
                 Variables:
                     KEYPHRASE_TABLE_NAME: !Ref KeyphrasesTable
+Outputs:
+    WebSocketAPIEndpoint:
+        Description: The endpoint for the Keyhrase service's WebSocket API
+        Value: !GetAtt KeyphraseWebSocketGateway.ApiEndpoint

--- a/services/keyphrase/libs/keyphrase-repository-library/schemas/KeyphraseTableTotalSchema.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/schemas/KeyphraseTableTotalSchema.ts
@@ -24,7 +24,7 @@ const schema = new Schema({
         index: {
             name: KeyphraseTableConstants.KeyphraseUsageIndexName,
             rangeKey: KeyphraseTableKeyFields.HashKey,
-            project: false,
+            project: [KeyphraseTableNonKeyFields.Occurrences],
         },
         required: true,
     },


### PR DESCRIPTION
# What

Updated keyphrase table usage index to project occurrences attribute of total items
Updated keyphrase service template to output WebSocket API endpoint

# Why

Index change:
- Enables further queries to be made against the data in this index, such as retrieving the top 5 websites that use a given keyphrase.
    - Without requiring subsequent queries

Template output:
- To allow easier set up of local environment, removing need to access console to get WebSocket API endpoint 