### PR TITLE
Feature/311 code splitting

### DIFF
--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -1,5 +1,6 @@
-import React, { Fragment } from "react";
+import React, { Fragment, Suspense } from "react";
 import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
+import { Spin } from "antd";
 
 import KeyphraseServiceClientFactory from "../clients/interfaces/KeyphraseServiceClientFactory";
 import SiteLayout from "./SiteLayout";
@@ -13,6 +14,8 @@ type AppProps = {
     keyphraseServiceClientFactory: KeyphraseServiceClientFactory;
 };
 
+const LOADING_MESSAGE = "Loading...";
+
 function App(props: AppProps) {
     return (
         <BrowserRouter>
@@ -22,21 +25,27 @@ function App(props: AppProps) {
                     <Route
                         path="results"
                         element={
-                            <Results
-                                keyphraseServiceClientFactory={
-                                    props.keyphraseServiceClientFactory
-                                }
-                            />
-                        }
-                    >
-                        <Route
-                            path=":url"
-                            element={
+                            <Suspense fallback={<Spin tip={LOADING_MESSAGE} />}>
                                 <Results
                                     keyphraseServiceClientFactory={
                                         props.keyphraseServiceClientFactory
                                     }
                                 />
+                            </Suspense>
+                        }
+                    >
+                        <Route
+                            path=":url"
+                            element={
+                                <Suspense
+                                    fallback={<Spin tip={LOADING_MESSAGE} />}
+                                >
+                                    <Results
+                                        keyphraseServiceClientFactory={
+                                            props.keyphraseServiceClientFactory
+                                        }
+                                    />
+                                </Suspense>
                             }
                         />
                     </Route>

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -2,9 +2,10 @@ import React, { Fragment } from "react";
 import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 
 import KeyphraseServiceClientFactory from "../clients/interfaces/KeyphraseServiceClientFactory";
-import Results from "./Results";
-import { Search } from "./Search";
 import SiteLayout from "./SiteLayout";
+
+const Search = React.lazy(() => import("./Search"));
+const Results = React.lazy(() => import("./Results"));
 
 import "../css/App.css";
 

--- a/ui/src/components/Search.tsx
+++ b/ui/src/components/Search.tsx
@@ -1,18 +1,11 @@
 import React, { Fragment, useState } from "react";
-import { gql, useMutation } from "@apollo/client";
+import { useMutation } from "@apollo/client";
 import { Navigate } from "react-router-dom";
 
 import { URLInput } from "./URLInput";
 import { CrawlingSpinner } from "./CrawlingSpinner";
 import CrawlStatus from "../enums/CrawlStatus";
-
-const START_CRAWL_MUTATION = gql`
-    mutation StartCrawl($input: StartCrawlInput!) {
-        startCrawl(input: $input) {
-            started
-        }
-    }
-`;
+import START_CRAWL_MUTATION from "../graphql/StartCrawlMutation";
 
 type StartCrawlInput = {
     url: string;
@@ -89,4 +82,4 @@ function Search() {
     );
 }
 
-export { Search, START_CRAWL_MUTATION };
+export default Search;

--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -36,34 +36,40 @@ beforeEach(() => {
 });
 
 describe("navigating to root", () => {
-    test("displays the title of the site in a header", () => {
+    test("displays the title of the site in a header", async () => {
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        expect(
-            getByRole("heading", { name: APPLICATION_TITLE })
-        ).toBeInTheDocument();
+        await waitFor(() =>
+            expect(
+                getByRole("heading", { name: APPLICATION_TITLE })
+            ).toBeInTheDocument()
+        );
     });
 
-    test("displays a URL textbox with an appropriate label", () => {
+    test("displays a URL textbox with an appropriate label", async () => {
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        expect(
-            getByRole("textbox", { name: URL_INPUT_LABEL })
-        ).toBeInTheDocument();
+        await waitFor(() =>
+            expect(
+                getByRole("textbox", { name: URL_INPUT_LABEL })
+            ).toBeInTheDocument()
+        );
     });
 
-    test("displays a search button", () => {
+    test("displays a search button", async () => {
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        expect(
-            getByRole("button", { name: SEARCH_BUTTON_TEXT })
-        ).toBeInTheDocument();
+        await waitFor(() =>
+            expect(
+                getByRole("button", { name: SEARCH_BUTTON_TEXT })
+            ).toBeInTheDocument()
+        );
     });
 });
 
@@ -81,26 +87,30 @@ describe("navigating to results with valid encoded URL", () => {
         );
     });
 
-    test("displays the title of the site in a header", () => {
+    test("displays the title of the site in a header", async () => {
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        expect(
-            getByRole("heading", { name: APPLICATION_TITLE })
-        ).toBeInTheDocument();
+        await waitFor(() =>
+            expect(
+                getByRole("heading", { name: APPLICATION_TITLE })
+            ).toBeInTheDocument()
+        );
     });
 
-    test("renders results header", () => {
+    test("renders results header", async () => {
         const expectedHeader = `Results for: ${VALID_URL}`;
 
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        expect(
-            getByRole("heading", { name: expectedHeader })
-        ).toBeInTheDocument();
+        await waitFor(() =>
+            expect(
+                getByRole("heading", { name: expectedHeader })
+            ).toBeInTheDocument()
+        );
     });
 });
 
@@ -110,16 +120,18 @@ test.each([
     ["an invalid encoded url (IP)", encodeURIComponent(0)],
 ])(
     "navigating to the results page with %s redirects to search page",
-    (message: string, url?: string) => {
+    async (message: string, url?: string) => {
         window.history.pushState({}, "", `/results/${url}`);
 
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        expect(
-            getByRole("textbox", { name: URL_INPUT_LABEL })
-        ).toBeInTheDocument();
+        await waitFor(() =>
+            expect(
+                getByRole("textbox", { name: URL_INPUT_LABEL })
+            ).toBeInTheDocument()
+        );
         expect(
             getByRole("button", { name: SEARCH_BUTTON_TEXT })
         ).toBeInTheDocument();

--- a/ui/src/components/__tests__/Search.test.tsx
+++ b/ui/src/components/__tests__/Search.test.tsx
@@ -8,7 +8,8 @@ import {
     createStatusUpdateMock,
     createStartCrawlMock,
 } from "./helpers/utils";
-import { Search, START_CRAWL_MUTATION } from "../Search";
+import Search from "../Search";
+import START_CRAWL_MUTATION from "../../graphql/StartCrawlMutation";
 import CrawlStatus from "../../enums/CrawlStatus";
 
 const URL_INPUT_LABEL = "URL";

--- a/ui/src/components/__tests__/helpers/utils.tsx
+++ b/ui/src/components/__tests__/helpers/utils.tsx
@@ -3,7 +3,7 @@ import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { render } from "@testing-library/react";
 
 import { CRAWL_STATUS_UPDATE_SUBSCRIPTION } from "../../CrawlingSpinner";
-import { START_CRAWL_MUTATION } from "../../Search";
+import START_CRAWL_MUTATION from "../../../graphql/StartCrawlMutation";
 import CrawlStatus from "../../../enums/CrawlStatus";
 
 function renderWithMockProvider(

--- a/ui/src/graphql/StartCrawlMutation.ts
+++ b/ui/src/graphql/StartCrawlMutation.ts
@@ -1,0 +1,11 @@
+import { gql } from "@apollo/client";
+
+const START_CRAWL_MUTATION = gql`
+    mutation StartCrawl($input: StartCrawlInput!) {
+        startCrawl(input: $input) {
+            started
+        }
+    }
+`;
+
+export default START_CRAWL_MUTATION;


### PR DESCRIPTION
Resolves #311 

# What

Update App.tsx to lazy load results and search components
- Showing spinner while components load

Separated Start crawl mutation operation into own file
Updated Search component to be exported as default export
Reduced the bundle size for initially downloaded bundle from 3MB to 1.7MB

# Why

To reduce the amount of data a user of the application needs to download before they see the initial page
- Only download what they require.
- The next largest aspect of the bundle is the Ant Design CSS file (approx 700KB)

Default export + Start Crawl Mutation separation:
- React.lazy only works with default exports and separating GraphQL mutation allows for re-use across the application

