### PR TITLE
Feature/result sorting

### DIFF
--- a/ui/src/components/Results.tsx
+++ b/ui/src/components/Results.tsx
@@ -36,6 +36,8 @@ const columns: ColumnsType<GroupedOccurrences> = [
         title: "Occurrences",
         dataIndex: "occurrences",
         key: "occurrences",
+        sorter: (a, b) => a.occurrences - b.occurrences,
+        defaultSortOrder: "descend",
     },
 ];
 


### PR DESCRIPTION
# What

Updated Results page to enable sorting of keyphrases by occurrences
- Defaults to showing most frequently occurring keyphrases first

# Why

To allow the user to more effectively analyse the data returned
