### PR TITLE
Feature/results pagination

### DIFF
--- a/ui/src/components/Results.tsx
+++ b/ui/src/components/Results.tsx
@@ -160,7 +160,6 @@ function Results(props: ResultsProps) {
                     <Table
                         columns={columns}
                         dataSource={groupedResults}
-                        pagination={false}
                         locale={{
                             emptyText: (
                                 <Empty

--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -87,20 +87,8 @@ describe("navigating to results with valid encoded URL", () => {
         );
     });
 
-    test("displays the title of the site in a header", async () => {
-        const { getByRole } = renderWithMockProvider(
-            <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
-        );
-
-        await waitFor(() =>
-            expect(
-                getByRole("heading", { name: APPLICATION_TITLE })
-            ).toBeInTheDocument()
-        );
-    });
-
-    test("renders results header", async () => {
-        const expectedHeader = `Results for: ${VALID_URL}`;
+    test("displays the title of the site and results message in headers", async () => {
+        const expectedResultsHeader = `Results for: ${VALID_URL}`;
 
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
@@ -108,9 +96,12 @@ describe("navigating to results with valid encoded URL", () => {
 
         await waitFor(() =>
             expect(
-                getByRole("heading", { name: expectedHeader })
+                getByRole("heading", { name: expectedResultsHeader })
             ).toBeInTheDocument()
         );
+        expect(
+            getByRole("heading", { name: APPLICATION_TITLE })
+        ).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
# What

Updated Results page to paginate keyphrase occurrences (default 10 per page)
Combined header tests for results page in App.test.tsx

# Why

Results pagination: To reduce the amount of rows shown at any one time, improving results presentation and readability

Header test combination: The test for site header was throwing an error as rendering was occurring outside the test execution