### PR TITLE
Feature/353 UI env script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,6 @@ jobs:
             path: ./ui
         secrets:
             DEPLOY_ROLE: ${{ secrets.AWS_DEPLOY_ROLE }}
-            REGION: ${{ secrets.REGION }}
-            CRAWL_SERVICE_GRAPHQL_ENDPOINT: ${{ secrets.CRAWL_SERVICE_GRAPHQL_ENDPOINT }}
-            CRAWL_IDENTITY_POOL_ID: ${{ secrets.CRAWL_IDENTITY_POOL_ID }}
-            KEYPHRASE_SERVICE_WS_ENDPOINT: ${{ secrets.KEYPHRASE_SERVICE_WS_ENDPOINT }}
     validate:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,14 +7,6 @@ on:
         secrets:
             DEPLOY_ROLE:
                 required: true
-            REGION:
-                required: true
-            CRAWL_SERVICE_GRAPHQL_ENDPOINT:
-                required: true
-            CRAWL_IDENTITY_POOL_ID:
-                required: true
-            KEYPHRASE_SERVICE_WS_ENDPOINT:
-                required: true
 
 jobs:
     changed:
@@ -162,16 +154,6 @@ jobs:
               with:
                   aws-region: eu-west-2
                   role-to-assume: ${{ secrets.DEPLOY_ROLE }}
-            - name: Create production envfile
-              uses: SpicyPizza/create-envfile@v1.3
-              with:
-                  envkey_REGION: ${{ secrets.REGION }}
-                  envkey_CRAWL_SERVICE_GRAPHQL_ENDPOINT: ${{ secrets.CRAWL_SERVICE_GRAPHQL_ENDPOINT }}
-                  envkey_CRAWL_IDENTITY_POOL_ID: ${{ secrets.CRAWL_IDENTITY_POOL_ID }}
-                  envkey_KEYPHRASE_WS_SERVICE_ENDPOINT: ${{ secrets.KEYPHRASE_SERVICE_WS_ENDPOINT }}
-                  directory: ${{ inputs.path }}
-                  file_name: .env
-                  fail_on_empty: true
             - name: Deploy stack
               run: |
                   ./scripts/deploy-ui.sh -e production -f -c

--- a/README.md
+++ b/README.md
@@ -73,12 +73,14 @@ Run the following commands to teardown all deployed components, along with their
 
 ### Running the SPA component locally
 
-Requires a `.env` file in the `./ui/` folder with the following values configured to the environment at test:
+Generate a `.env` file in the `./ui` folder by running the following the command:
 
-| Environment Variable          | Description                                                  |
-| ----------------------------- | ------------------------------------------------------------ |
-| CRAWL_SERVICE_ENDPOINT        | The HTTP API Gateway endpoint for the crawl service          |
-| KEYPHRASE_WS_SERVICE_ENDPOINT | The WebSocket API Gateway endpoint for the keyphrase service |
+```
+./scripts/helpers/generate-ui-env.sh \
+    -c $INSERT_NAME_OF_CRAWL_STACK \
+    -k $INSERT_NAME_OF_KEYPHRASE_STACK \
+    -o ./ui/.env
+```
 
 Run the following script to run the UI locally:
 

--- a/scripts/deploy-ui.sh
+++ b/scripts/deploy-ui.sh
@@ -35,6 +35,30 @@ fi
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 root_dir="$( dirname "$script_dir")"
 
+crawl_config_path="$root_dir/services/crawl/samconfig.toml"
+if [ ! -f $crawl_config_path ]; then
+    echo "Error: Cannot find crawl config file."
+    exit 1
+fi
+
+crawl_stack_name=$(node $script_dir/helpers/get-sam-config-value.js -c $crawl_config_path -e $environment -v stack_name)
+
+keyphrase_config_path="$root_dir/services/keyphrase/samconfig.toml"
+if [ ! -f $crawl_config_path ]; then
+    echo "Error: Cannot find keyphrase config file."
+    exit 1
+fi
+
+keyphrase_stack_name=$(node $script_dir/helpers/get-sam-config-value.js -c $keyphrase_config_path -e $environment -v stack_name)
+
+echo "Creating .env file for environment: $environment..."
+$script_dir/helpers/generate-ui-env.sh -c $crawl_stack_name -k $keyphrase_stack_name -o $root_dir/ui/.env
+
+if [ $? -ne 0 ]; then
+    echo "Error: An error occured generating .env file for environment."
+    exit 1
+fi
+
 echo "Removing existing build artefacts..."
 rm -rf "$root_dir/ui/dist"
 

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -1,8 +1,40 @@
 #!/bin/bash
 
-crawl_stack="buzzword-crawl-service-dev"
-keyphrase_stack="buzzword-keyphrase-service-dev"
-region="eu-west-2"
+usage() {
+    echo "Usage:
+    -c [Mandatory: Name of the crawl service stack to target]
+    -k [Mandatory: Name of the keyphrase service stack to target]
+    -r [The region the stacks reside in]" 1>&2;
+    exit 1; 
+}
+
+while getopts "c:k:r:h" opt; do
+    case $opt in
+        c)
+            crawl_stack=$OPTARG
+            ;;
+        k)
+            keyphrase_stack=$OPTARG
+            ;;
+        r)
+            region=$OPTARG
+            ;;
+        h)
+            usage
+            ;;
+        ?)
+            usage
+            ;;
+    esac
+done
+
+if [ -z $crawl_stack ] || [ -z $keyphrase_stack ]; then
+    usage 
+fi
+
+if [ -z $region]; then
+    region="eu-west-2"
+fi
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
@@ -20,7 +52,6 @@ if [ -z $crawl_identity_pool_id ]; then
     echo "Error: No Crawl Identity Pool ID found in crawl stack output."
     exit 1
 fi
-
 
 keyphrase_stack_output=$($script_dir/fetch-stack-outputs.sh -s $keyphrase_stack -r $region)
 keyphrase_service_ws_endpoint=$(echo $keyphrase_stack_output | jq -r 'select ( .OutputKey == "WebSocketAPIEndpoint") | .OutputValue')

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -36,7 +36,7 @@ if [ -z $crawl_stack ] || [ -z $keyphrase_stack ]; then
     usage 
 fi
 
-if [ -z $region]; then
+if [ -z $region ]; then
     region="eu-west-2"
 fi
 

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -4,11 +4,12 @@ usage() {
     echo "Usage:
     -c [Mandatory: Name of the crawl service stack to target]
     -k [Mandatory: Name of the keyphrase service stack to target]
-    -r [The region the stacks reside in]" 1>&2;
+    -r [The region the stacks reside in]
+    -o [The location to create the .env in]" 1>&2;
     exit 1; 
 }
 
-while getopts "c:k:r:h" opt; do
+while getopts "c:k:r:o:h" opt; do
     case $opt in
         c)
             crawl_stack=$OPTARG
@@ -18,6 +19,9 @@ while getopts "c:k:r:h" opt; do
             ;;
         r)
             region=$OPTARG
+            ;;
+        o)
+            output_path=$OPTARG
             ;;
         h)
             usage
@@ -34,6 +38,18 @@ fi
 
 if [ -z $region]; then
     region="eu-west-2"
+fi
+
+if [ -z $output_path ]; then
+    output_path=".env"
+elif [ -d $output_path ]; then
+    output_path="$output_path/.env"
+else
+    file_name=$(basename $output_path)
+    if [ $file_name != ".env" ]; then
+        echo "Error: Provided output file must be named .env"
+        exit 1
+    fi
 fi
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -61,7 +77,7 @@ if [ -z $keyphrase_service_ws_endpoint ]; then
     exit 1
 fi
 
-echo "REGION=\"$region\"" > .env
-echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" >> .env
-echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> .env
-echo "KEYPHRASE_WS_SERVICE_ENDPOINT=\"$keyphrase_service_ws_endpoint/\$default\"" >> .env
+echo "REGION=\"$region\"" > $output_path
+echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" >> $output_path
+echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> $output_path
+echo "KEYPHRASE_WS_SERVICE_ENDPOINT=\"$keyphrase_service_ws_endpoint/\$default\"" >> $output_path

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -1,19 +1,24 @@
+#!/bin/bash
+
 crawl_stack="buzzword-crawl-service-dev"
 keyphrase_stack="buzzword-keyphrase-service-dev"
+region="eu-west-2"
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-crawl_stack_output=$($script_dir/fetch-stack-outputs.sh -s $crawl_stack)
+echo "REGION=\"$region\"" > .env
+
+crawl_stack_output=$($script_dir/fetch-stack-outputs.sh -s $crawl_stack -r $region)
 
 crawl_graphql_endpoint=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlGraphQLAPIEndpoint") | .OutputValue')
 
-echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" > .env
+echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" >> .env
 
 crawl_identity_pool_id=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlIdentityPoolID") | .OutputValue')
 
 echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> .env
 
-keyphrase_stack_output=$($script_dir/fetch-stack-outputs.sh -s $keyphrase_stack)
+keyphrase_stack_output=$($script_dir/fetch-stack-outputs.sh -s $keyphrase_stack -r $region)
 
 keyphrase_service_ws_endpoint=$(echo $keyphrase_stack_output | jq -r 'select ( .OutputKey == "WebSocketAPIEndpoint") | .OutputValue')
 

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -1,4 +1,5 @@
 crawl_stack="buzzword-crawl-service-dev"
+keyphrase_stack="buzzword-keyphrase-service-dev"
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
@@ -11,3 +12,9 @@ echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" > .env
 crawl_identity_pool_id=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlIdentityPoolID") | .OutputValue')
 
 echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> .env
+
+keyphrase_stack_output=$($script_dir/fetch-stack-outputs.sh -s $keyphrase_stack)
+
+keyphrase_service_ws_endpoint=$(echo $keyphrase_stack_output | jq -r 'select ( .OutputKey == "WebSocketAPIEndpoint") | .OutputValue')
+
+echo "KEYPHRASE_WS_SERVICE_ENDPOINT=\"$keyphrase_service_ws_endpoint/\$default\"" >> .env

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -6,20 +6,31 @@ region="eu-west-2"
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-echo "REGION=\"$region\"" > .env
-
 crawl_stack_output=$($script_dir/fetch-stack-outputs.sh -s $crawl_stack -r $region)
-
 crawl_graphql_endpoint=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlGraphQLAPIEndpoint") | .OutputValue')
 
-echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" >> .env
+if [ -z $crawl_graphql_endpoint ]; then
+    echo "Error: No Crawl GraphQL Endpoint found in crawl stack output."
+    exit 1
+fi
 
 crawl_identity_pool_id=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlIdentityPoolID") | .OutputValue')
 
-echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> .env
+if [ -z $crawl_identity_pool_id ]; then
+    echo "Error: No Crawl Identity Pool ID found in crawl stack output."
+    exit 1
+fi
+
 
 keyphrase_stack_output=$($script_dir/fetch-stack-outputs.sh -s $keyphrase_stack -r $region)
-
 keyphrase_service_ws_endpoint=$(echo $keyphrase_stack_output | jq -r 'select ( .OutputKey == "WebSocketAPIEndpoint") | .OutputValue')
 
+if [ -z $keyphrase_service_ws_endpoint ]; then
+    echo "Error: No Keyphrase WebSocket Endpoint found in keyphrase stack output."
+    exit 1
+fi
+
+echo "REGION=\"$region\"" > .env
+echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" >> .env
+echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> .env
 echo "KEYPHRASE_WS_SERVICE_ENDPOINT=\"$keyphrase_service_ws_endpoint/\$default\"" >> .env

--- a/scripts/helpers/generate-ui-env.sh
+++ b/scripts/helpers/generate-ui-env.sh
@@ -1,0 +1,13 @@
+crawl_stack="buzzword-crawl-service-dev"
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+crawl_stack_output=$($script_dir/fetch-stack-outputs.sh -s $crawl_stack)
+
+crawl_graphql_endpoint=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlGraphQLAPIEndpoint") | .OutputValue')
+
+echo "CRAWL_SERVICE_GRAPHQL_ENDPOINT=\"$crawl_graphql_endpoint\"" > .env
+
+crawl_identity_pool_id=$(echo $crawl_stack_output | jq -r 'select ( .OutputKey == "CrawlIdentityPoolID") | .OutputValue')
+
+echo "CRAWL_IDENTITY_POOL_ID=\"$crawl_identity_pool_id\"" >> .env


### PR DESCRIPTION
Resolves #353 

# What

Added `generate-ui-env.sh` script to create a .env file at a given location with all environment variables required by the UI to function
- Programatically obtains the values for each variable from the provided stacks

Updated UI deployment script to generate .env file before building UI bundle
Updated README with instructions on how to generate .env file for local development
Updated pipeline configuration to remove redundant generation of .env file from secrets

# Why

To remove the manual steps involved with setting these secrets in GitHub and when setting up local environments.