### PR TITLE
fix/ui deploy missing node dependency 

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -23,6 +23,7 @@ jobs:
                       ui:
                         - ${{ inputs.path }}/**
                         - ./.github/workflows/ui.yml
+                        - ./scripts/deploy-ui.sh
     audit:
         runs-on: ubuntu-latest
         steps:

--- a/scripts/deploy-ui.sh
+++ b/scripts/deploy-ui.sh
@@ -35,6 +35,9 @@ fi
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 root_dir="$( dirname "$script_dir")"
 
+echo "Installing UI dependencies..."
+npm --prefix "$root_dir/ui/" run ci
+
 crawl_config_path="$root_dir/services/crawl/samconfig.toml"
 if [ ! -f $crawl_config_path ]; then
     echo "Error: Cannot find crawl config file."


### PR DESCRIPTION
# What

Updated `deploy-ui.sh` to run lerna bootstrap before running rest of script to fix missing yargs dependency issue
Updated `ui.yml` to trigger UI deployment if ui deployment script is changed

# Why

UI deployments are currently failing as the yargs package is required in the running of the UI deployment