### PR TITLE
Fix/352 missing page return to site link

### DIFF
--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, Suspense } from "react";
+import React, { Fragment, ReactElement, Suspense } from "react";
 import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 import { Spin } from "antd";
 
@@ -14,7 +14,17 @@ type AppProps = {
     keyphraseServiceClientFactory: KeyphraseServiceClientFactory;
 };
 
-const LOADING_MESSAGE = "Loading...";
+type LazyLoadingProps = {
+    children: ReactElement;
+};
+
+function LazyLoadingWrapper(props: LazyLoadingProps): ReactElement {
+    return (
+        <Suspense fallback={<Spin tip="Loading..." />}>
+            {props.children}
+        </Suspense>
+    );
+}
 
 function App(props: AppProps) {
     return (
@@ -24,35 +34,33 @@ function App(props: AppProps) {
                     <Route
                         index
                         element={
-                            <Suspense fallback={<Spin tip={LOADING_MESSAGE} />}>
+                            <LazyLoadingWrapper>
                                 <Search />
-                            </Suspense>
+                            </LazyLoadingWrapper>
                         }
                     />
                     <Route
                         path="results"
                         element={
-                            <Suspense fallback={<Spin tip={LOADING_MESSAGE} />}>
+                            <LazyLoadingWrapper>
                                 <Results
                                     keyphraseServiceClientFactory={
                                         props.keyphraseServiceClientFactory
                                     }
                                 />
-                            </Suspense>
+                            </LazyLoadingWrapper>
                         }
                     >
                         <Route
                             path=":url"
                             element={
-                                <Suspense
-                                    fallback={<Spin tip={LOADING_MESSAGE} />}
-                                >
+                                <LazyLoadingWrapper>
                                     <Results
                                         keyphraseServiceClientFactory={
                                             props.keyphraseServiceClientFactory
                                         }
                                     />
-                                </Suspense>
+                                </LazyLoadingWrapper>
                             }
                         />
                     </Route>

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, ReactElement, Suspense } from "react";
 import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
-import { Spin } from "antd";
+import { Button, Spin } from "antd";
 
 import KeyphraseServiceClientFactory from "../clients/interfaces/KeyphraseServiceClientFactory";
 import SiteLayout from "./SiteLayout";
@@ -69,7 +69,9 @@ function App(props: AppProps) {
                         element={
                             <Fragment>
                                 <p>Oh no! You&apos;ve gotten lost!</p>
-                                <Link to="/">Return to search</Link>
+                                <Button type="primary">
+                                    <Link to="/">Return to search</Link>
+                                </Button>
                             </Fragment>
                         }
                     />

--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -21,7 +21,14 @@ function App(props: AppProps) {
         <BrowserRouter>
             <Routes>
                 <Route path="/" element={<SiteLayout />}>
-                    <Route index element={<Search />} />
+                    <Route
+                        index
+                        element={
+                            <Suspense fallback={<Spin tip={LOADING_MESSAGE} />}>
+                                <Search />
+                            </Suspense>
+                        }
+                    />
                     <Route
                         path="results"
                         element={

--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -36,19 +36,7 @@ beforeEach(() => {
 });
 
 describe("navigating to root", () => {
-    test("displays the title of the site in a header", async () => {
-        const { getByRole } = renderWithMockProvider(
-            <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
-        );
-
-        await waitFor(() =>
-            expect(
-                getByRole("heading", { name: APPLICATION_TITLE })
-            ).toBeInTheDocument()
-        );
-    });
-
-    test("displays a URL textbox with an appropriate label", async () => {
+    test("displays the title of the site alongside the search input", async () => {
         const { getByRole } = renderWithMockProvider(
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
@@ -58,18 +46,12 @@ describe("navigating to root", () => {
                 getByRole("textbox", { name: URL_INPUT_LABEL })
             ).toBeInTheDocument()
         );
-    });
-
-    test("displays a search button", async () => {
-        const { getByRole } = renderWithMockProvider(
-            <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
-        );
-
-        await waitFor(() =>
-            expect(
-                getByRole("button", { name: SEARCH_BUTTON_TEXT })
-            ).toBeInTheDocument()
-        );
+        expect(
+            getByRole("button", { name: SEARCH_BUTTON_TEXT })
+        ).toBeInTheDocument();
+        expect(
+            getByRole("heading", { name: APPLICATION_TITLE })
+        ).toBeInTheDocument();
     });
 });
 


### PR DESCRIPTION
Resolves #352 

# What

Updated App.tsx:
- To wrap Search component is Suspense to enable lazy loading
- Refactored lazy loading functionality into a function to reduce duplication across App.tsx
- To make the Return to Search button on the fallback page a primary button

# Why

Return to Search button was causing an error to be thrown when the user was redirected back to the index page, this was caused by the Search component not being wrapped in a suspense - i.e. that component had not been loaded yet and was requested before it was ready.

Primary button change: The return to search button is the main / only action on that page - Updated to follow ant design guidelines for buttons with these characteristics