### PR TITLE
Feature/351 prevent redundant totals

### DIFF
--- a/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
@@ -1,6 +1,7 @@
 import {
     Repository,
     SiteKeyphraseOccurrences,
+    SiteKeyphrase,
 } from "buzzword-keyphrase-keyphrase-repository-library";
 
 import {
@@ -13,41 +14,70 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
     constructor(private repository: Repository) {}
 
     async updateTotal(items: (OccurrenceItem | TotalItem)[]): Promise<boolean> {
-        const occurrencesToTotal = this.createTotalUpdates(items);
-        if (occurrencesToTotal.length == 0) {
-            return true;
+        const totals = this.createTotalUpdates(items);
+
+        let result = true;
+        if (totals.additions.length > 0) {
+            result = await this.addOccurrences(totals.additions);
         }
 
+        if (totals.aggregated.length > 0) {
+            result = await this.updateAggregateFlags(totals.aggregated);
+        }
+
+        return result;
+    }
+
+    private async addOccurrences(
+        additions: SiteKeyphraseOccurrences[]
+    ): Promise<boolean> {
         try {
-            return await this.repository.addOccurrencesToTotals(
-                occurrencesToTotal
-            );
+            return await this.repository.addOccurrencesToTotals(additions);
         } catch {
             return false;
         }
     }
 
-    private createTotalUpdates(
-        items: (OccurrenceItem | TotalItem)[]
-    ): SiteKeyphraseOccurrences[] {
-        return items.reduce((acc: SiteKeyphraseOccurrences[], item) => {
+    private async updateAggregateFlags(
+        items: SiteKeyphrase[]
+    ): Promise<boolean> {
+        return await this.repository.setKeyphraseAggregated(items);
+    }
+
+    private createTotalUpdates(items: (OccurrenceItem | TotalItem)[]): {
+        additions: SiteKeyphraseOccurrences[];
+        aggregated: SiteKeyphrase[];
+    } {
+        const newAdditions: SiteKeyphraseOccurrences[] = [];
+        const alreadyAggregated: SiteKeyphrase[] = [];
+
+        for (const item of items) {
             if (this.isOccurrenceItem(item)) {
                 const newOccurrences = item.previous
                     ? item.current.occurrences - item.previous.occurrences
                     : item.current.occurrences;
 
                 if (newOccurrences != 0) {
-                    acc.push({
+                    newAdditions.push({
                         baseURL: item.current.baseURL,
                         pathname: item.current.pathname,
                         keyphrase: item.current.keyphrase,
                         occurrences: newOccurrences,
                     });
+                } else {
+                    alreadyAggregated.push({
+                        baseURL: item.current.baseURL,
+                        pathname: item.current.pathname,
+                        keyphrase: item.current.keyphrase,
+                    });
                 }
             }
+        }
 
-            return acc;
-        }, []);
+        return {
+            additions: newAdditions,
+            aggregated: alreadyAggregated,
+        };
     }
 
     private isOccurrenceItem(

--- a/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
@@ -36,12 +36,14 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
                     ? item.current.occurrences - item.previous.occurrences
                     : item.current.occurrences;
 
-                acc.push({
-                    baseURL: item.current.baseURL,
-                    pathname: item.current.pathname,
-                    keyphrase: item.current.keyphrase,
-                    occurrences: newOccurrences,
-                });
+                if (newOccurrences != 0) {
+                    acc.push({
+                        baseURL: item.current.baseURL,
+                        pathname: item.current.pathname,
+                        keyphrase: item.current.keyphrase,
+                        occurrences: newOccurrences,
+                    });
+                }
             }
 
             return acc;

--- a/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
@@ -41,7 +41,11 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
     private async updateAggregateFlags(
         items: SiteKeyphrase[]
     ): Promise<boolean> {
-        return await this.repository.setKeyphraseAggregated(items);
+        try {
+            return await this.repository.setKeyphraseAggregated(items);
+        } catch {
+            return false;
+        }
     }
 
     private createTotalUpdates(items: (OccurrenceItem | TotalItem)[]): {

--- a/services/keyphrase/functions/total-occurrences/domain/__tests__/TotalOccurrencesDomain.test.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/__tests__/TotalOccurrencesDomain.test.ts
@@ -295,3 +295,31 @@ describe.each([
         );
     });
 });
+
+test("returns failure if updating aggregated flag throws an error", async () => {
+    mockRepository.setKeyphraseAggregated.mockRejectedValue(new Error());
+    const items = [
+        {
+            current: createOccurrenceImage(VALID_URL, "test", 3),
+            previous: createOccurrenceImage(VALID_URL, "test", 3),
+        },
+    ];
+
+    const actual = await domain.updateTotal(items);
+
+    expect(actual).toBe(false);
+});
+
+test("returns failure if updating aggregated flag does not succeed", async () => {
+    mockRepository.setKeyphraseAggregated.mockResolvedValue(false);
+    const items = [
+        {
+            current: createOccurrenceImage(VALID_URL, "test", 3),
+            previous: createOccurrenceImage(VALID_URL, "test", 3),
+        },
+    ];
+
+    const actual = await domain.updateTotal(items);
+
+    expect(actual).toBe(false);
+});

--- a/services/keyphrase/functions/total-occurrences/domain/__tests__/TotalOccurrencesDomain.test.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/__tests__/TotalOccurrencesDomain.test.ts
@@ -243,3 +243,35 @@ test.each([
         );
     }
 );
+
+test.each([
+    [
+        "a single occurrence item",
+        [
+            {
+                current: createOccurrenceImage(VALID_URL, "test", 3),
+                previous: createOccurrenceImage(VALID_URL, "test", 3),
+            },
+        ],
+    ],
+    [
+        "multiple occurrence items",
+        [
+            {
+                current: createOccurrenceImage(VALID_URL, "test", 3),
+                previous: createOccurrenceImage(VALID_URL, "test", 3),
+            },
+            {
+                current: createOccurrenceImage(VALID_URL, "wibble", 5),
+                previous: createOccurrenceImage(VALID_URL, "wibble", 5),
+            },
+        ],
+    ],
+])(
+    "does not attempt to persist addition given %s whose occurrence count has not changed",
+    async (message: string, items: OccurrenceItem[]) => {
+        await domain.updateTotal(items);
+
+        expect(mockRepository.addOccurrencesToTotals).not.toHaveBeenCalled();
+    }
+);

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -420,6 +420,10 @@ class KeyphraseRepository implements Repository {
                 },
                 { condition }
             );
+
+            console.log(
+                `Successfully set aggregated flag for: ${JSON.stringify(item)}`
+            );
         } catch (ex) {
             console.error(
                 `An error occurred setting aggregated flag for: ${JSON.stringify(

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -403,14 +403,32 @@ class KeyphraseRepository implements Repository {
     }
 
     private async setAggregatedFlag(item: SiteKeyphrase): Promise<boolean> {
+        const condition = new dynamoose.Condition()
+            .filter(KeyphraseTableNonKeyFields.Aggregated)
+            .exists();
         const itemKey = this.createOccurrenceKey(
             item.baseURL,
             item.pathname,
             item.keyphrase
         );
-        await this.occurrenceModel.update(itemKey, {
-            [KeyphraseTableNonKeyFields.Aggregated]: true,
-        });
+
+        try {
+            await this.occurrenceModel.update(
+                itemKey,
+                {
+                    [KeyphraseTableNonKeyFields.Aggregated]: true,
+                },
+                { condition }
+            );
+        } catch (ex) {
+            console.error(
+                `An error occurred setting aggregated flag for: ${JSON.stringify(
+                    item
+                )}. Error: ${ex}`
+            );
+
+            return false;
+        }
 
         return true;
     }

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -796,6 +796,46 @@ describe("setting keyphrase to aggregated", () => {
         }
     );
 
+    test("returns success if item is already set to aggregated", async () => {
+        const occurrence = TEST_KEYPHRASES[0];
+        const keyphrase = extractKeyphraseKeys(VALID_URL, occurrence);
+        await repository.storeKeyphrases(
+            VALID_URL.hostname,
+            VALID_URL.pathname,
+            occurrence
+        );
+        await repository.setKeyphraseAggregated(keyphrase);
+
+        const actual = await repository.setKeyphraseAggregated(keyphrase);
+
+        expect(actual).toBe(true);
+    });
+
+    describe("updating non-existent keyphrase", () => {
+        const keyphrase = extractKeyphraseKeys(
+            VALID_URL,
+            TEST_KEYPHRASES[0]
+        ) as SiteKeyphrase;
+
+        test("returns failure", async () => {
+            const actual = await repository.setKeyphraseAggregated(keyphrase);
+
+            expect(actual).toBe(false);
+        });
+
+        test("does not create a item for this keyphrase", async () => {
+            await repository.setKeyphraseAggregated(keyphrase);
+
+            const actual = await repository.getOccurrences(
+                keyphrase.baseURL,
+                keyphrase.pathname,
+                keyphrase.keyphrase
+            );
+
+            expect(actual).toBeUndefined();
+        });
+    });
+
     afterEach(async () => {
         await repository.empty();
     });

--- a/services/keyphrase/libs/keyphrase-repository-library/index.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/index.ts
@@ -2,6 +2,7 @@ import {
     KeyphraseOccurrences,
     PathnameOccurrences,
     SiteKeyphraseOccurrences,
+    SiteKeyphrase,
     Repository,
 } from "./ports/Repository";
 import KeyphraseRepository from "./adapters/KeyphraseRepository";
@@ -15,6 +16,7 @@ export {
     KeyphraseOccurrences,
     PathnameOccurrences,
     SiteKeyphraseOccurrences,
+    SiteKeyphrase,
     Repository,
     KeyphraseRepository,
     KeyphraseTableKeyFields,

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -8,6 +8,10 @@ type SiteKeyphraseOccurrences = {
 
 type PathnameOccurrences = Omit<SiteKeyphraseOccurrences, "baseURL">;
 type KeyphraseOccurrences = Omit<PathnameOccurrences, "pathname">;
+type SiteKeyphrase = Omit<
+    SiteKeyphraseOccurrences,
+    "occurrences" | "aggregated"
+>;
 
 interface Repository {
     empty(): Promise<boolean>;
@@ -31,6 +35,9 @@ interface Repository {
         occurrences: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
     ): Promise<boolean>;
     getKeyphraseUsages(keyphrase: string): Promise<string[]>;
+    setKeyphraseAggregated(
+        keyphrases: SiteKeyphrase | SiteKeyphrase[]
+    ): Promise<boolean>;
 }
 
 export {
@@ -38,4 +45,5 @@ export {
     PathnameOccurrences,
     Repository,
     SiteKeyphraseOccurrences,
+    SiteKeyphrase,
 };


### PR DESCRIPTION
Resolves #351 

# What

Updated Total Occurrences lambda to only set aggregated flag to true if occurrence count has not changed or a given site keyphrase item
Updated Keyphrase Repository library to add a method to allow a keyphrase item(s) aggregated flag to be set to true

# Why

Previously the domain would call `addOccurrencesToTotals` regardless of whether the keyphrase occurrence hadn't changed. This resulted in a transaction being ran against DynamoDB which was mostly redundant.

The only operation required from the transaction was to set the aggregated flag to true as the other values would remain unchanged
