### PR TITLE
Chore/find keyphrase logging

### DIFF
--- a/services/crawl/crawl-template.yml
+++ b/services/crawl/crawl-template.yml
@@ -295,6 +295,7 @@ Resources:
                 - Ref: ContentRepositoryLibraryLayer
                 - Ref: CrawlNodeDependencyLayer
             Timeout: 6
+            MemorySize: 256
             Policies:
                 - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
                 - Version: "2012-10-17"

--- a/services/keyphrase/functions/find-keyphrases/domain/KeyphraseFinder.ts
+++ b/services/keyphrase/functions/find-keyphrases/domain/KeyphraseFinder.ts
@@ -18,11 +18,13 @@ class KeyphraseFinder implements KeyphrasesPort {
         const uniqueKeyphrases = new Set<string>();
         const content = await this.parsedContentRepository.getPageText(url);
         if (content) {
+            console.log(`Starting keyphrase analysis for: ${url.toString()}`);
             const parsedFile = await retext()
                 .use(retextPos)
                 .use(retextKeywords)
                 .process(content);
 
+            console.log(`Completed keyphrase analysis for: ${url.toString()}`);
             for (const keyword of parsedFile.data.keywords) {
                 const current = toString(keyword.matches[0].node).toLowerCase();
                 uniqueKeyphrases.add(current);

--- a/services/keyphrase/functions/find-keyphrases/domain/__tests__/KeyphraseFinder.test.ts
+++ b/services/keyphrase/functions/find-keyphrases/domain/__tests__/KeyphraseFinder.test.ts
@@ -23,6 +23,10 @@ const mockParsedContentProvider = mock<TextRepository>();
 
 const keyphraseFinder = new KeyphraseFinder(mockParsedContentProvider);
 
+beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
 beforeEach(() => {
     mockParsedContentProvider.getPageText.mockReset();
 });

--- a/services/keyphrase/functions/scrape-url/domain/ScrapeURLDomain.ts
+++ b/services/keyphrase/functions/scrape-url/domain/ScrapeURLDomain.ts
@@ -14,7 +14,11 @@ class ScrapeURLDomain implements ScrapeURLPort {
     async scrapeURL(url: URL): Promise<boolean> {
         try {
             const html = await this.crawlClient.getContent(url);
+
+            console.log(`Starting HTML parsing for: ${url.toString()}`);
             const parsedHTML = this.htmlParser.parseHTML(html);
+            console.log(`Finished HTML parsing for: ${url.toString()}`);
+
             return await this.repository.storePageText(url, parsedHTML);
         } catch (ex) {
             const errorContent =

--- a/services/keyphrase/functions/scrape-url/domain/__tests__/ScrapeURLDomain.test.ts
+++ b/services/keyphrase/functions/scrape-url/domain/__tests__/ScrapeURLDomain.test.ts
@@ -20,6 +20,7 @@ const domain = new ScrapeURLDomain(
 );
 
 beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
     jest.spyOn(console, "error").mockImplementation(() => undefined);
 });
 

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -140,6 +140,7 @@ Resources:
             Layers:
                 - Ref: TextRepositoryLibraryLayer
             Timeout: 10
+            MemorySize: 256
             Architectures:
                 - arm64
             Environment:


### PR DESCRIPTION
# What

Doubled memory on GetContent and Find Keyphrases lambdas
Added logging to Parse URL and Find keyphrases to diagnose runtime of internal functions

# Why

Find keyphrases:
- Keyphrase analysis is particularly slow, some pages were hitting timeout due to this

Get Content:
- Init time for this lambda was approx 3.5 seconds prior, now around 1.4 seconds
- Used by keyphrase service so directly impacts time it takes to get keyphrase results