### PR TITLE
Chore/optimise critical path memory

### DIFF
--- a/services/crawl/crawl-template.yml
+++ b/services/crawl/crawl-template.yml
@@ -278,6 +278,7 @@ Resources:
             Layers:
                 - Ref: URLsRepositoryLibraryLayer
                 - Ref: CrawlNodeDependencyLayer
+            MemorySize: 1024
             Architectures:
                 - arm64
             Environment:
@@ -295,7 +296,7 @@ Resources:
                 - Ref: ContentRepositoryLibraryLayer
                 - Ref: CrawlNodeDependencyLayer
             Timeout: 6
-            MemorySize: 256
+            MemorySize: 512
             Policies:
                 - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
                 - Version: "2012-10-17"

--- a/services/keyphrase/keyphrase-state-machine.asl.json
+++ b/services/keyphrase/keyphrase-state-machine.asl.json
@@ -18,14 +18,8 @@
                         "Resource": "${ScrapeURLARN}",
                         "Retry": [
                             {
-                                "ErrorEquals": [
-                                    "Lambda.ServiceException",
-                                    "Lambda.AWSLambdaException",
-                                    "Lambda.SdkClientException",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.Unknown"
-                                ],
-                                "IntervalSeconds": 3,
+                                "ErrorEquals": ["States.ALL"],
+                                "IntervalSeconds": 2,
                                 "BackoffRate": 2.0,
                                 "MaxAttempts": 3
                             }
@@ -38,14 +32,8 @@
                         "Resource": "${FindKeyphrasesARN}",
                         "Retry": [
                             {
-                                "ErrorEquals": [
-                                    "Lambda.ServiceException",
-                                    "Lambda.AWSLambdaException",
-                                    "Lambda.SdkClientException",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.Unknown"
-                                ],
-                                "IntervalSeconds": 3,
+                                "ErrorEquals": ["States.ALL"],
+                                "IntervalSeconds": 2,
                                 "BackoffRate": 2.0,
                                 "MaxAttempts": 3
                             }
@@ -73,14 +61,8 @@
                         "Resource": "${CountOccurrencesARN}",
                         "Retry": [
                             {
-                                "ErrorEquals": [
-                                    "Lambda.ServiceException",
-                                    "Lambda.AWSLambdaException",
-                                    "Lambda.SdkClientException",
-                                    "Lambda.TooManyRequestsException",
-                                    "Lambda.Unknown"
-                                ],
-                                "IntervalSeconds": 3,
+                                "ErrorEquals": ["States.ALL"],
+                                "IntervalSeconds": 2,
                                 "BackoffRate": 2.0,
                                 "MaxAttempts": 3
                             }

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -140,7 +140,7 @@ Resources:
             Layers:
                 - Ref: TextRepositoryLibraryLayer
             Timeout: 10
-            MemorySize: 256
+            MemorySize: 1536
             Architectures:
                 - arm64
             Environment:
@@ -593,6 +593,7 @@ Resources:
             Layers:
                 - Ref: TextRepositoryLibraryLayer
             Timeout: 10
+            MemorySize: 512
             Architectures:
                 - arm64
             Environment:
@@ -644,6 +645,7 @@ Resources:
                 - Ref: KeyphraseRepositoryLibraryLayer
                 - Ref: TextRepositoryLibraryLayer
             Timeout: 10
+            MemorySize: 512
             Architectures:
                 - arm64
             Environment:


### PR DESCRIPTION
# What

Analysed affect of adding more memory to each lambda on critical path (those invoked by step functions) using https://github.com/alexcasalboni/aws-lambda-power-tuning.
Updated lambdas based on that output to optimise between cost and performance (Typically favouring lower cost)
Updated keyphrase service step function retry behaviour for lambdas to retry on any lambda or step function failure

# Why

Memory optimisation: To reduce the overall time it takes for any given URL to be crawled and its keyphrases analyzed. Resulted in approximately a 50% reduction in overall E2E processing time.

Keyphrase step function retry: Due to increased throughput, the count occurrences lambda in particular is now being throttled when writing to DynamoDB.
- Quick solution to solve this issue with exponential backoff
- However, likely a better solution would be to wrap the batch write operation with exponential backoff retry behaviour to prevent recounting of occurrences

# Tuning results

> Note each memory size was run against twenty times and the results were averaged to produce the below graphs

Scrape URLs and Get Content Lambda tuning results:

![scrape-url-power-tuning-results](https://user-images.githubusercontent.com/17100291/190867195-293e42a9-a882-4507-a8b8-8202c65b54d9.png)

Find keyphrases lambda tuning results:

![find-keyphrases-power-tuning-results](https://user-images.githubusercontent.com/17100291/190867214-6d31d4e3-4737-4d25-aac2-8c657f7b213b.png)

Count Occurrences lambda tuning results:

![count-occurrences-power-tuning-results](https://user-images.githubusercontent.com/17100291/190867233-4af722d4-b76d-4ae6-8ab1-b257dbed2dce.png)

Recent Crawl lambda tuning results:

![recent-crawl-power-tuning-results](https://user-images.githubusercontent.com/17100291/190867256-f5b51a42-449d-4db2-8957-5921cea3d5d6.png)
