### PR TITLE
Chore/optimise keyphrase stream processing

### DIFF
--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -550,9 +550,12 @@ Resources:
                     Type: DynamoDB
                     Properties:
                         Stream: !GetAtt KeyphrasesTable.StreamArn
-                        BatchSize: 10
+                        BatchSize: 100
                         StartingPosition: TRIM_HORIZON
                         MaximumRetryAttempts: 5
+                        FilterCriteria:
+                            Filters:
+                                - Pattern: '{ "dynamodb": { "Keys": { "pk": { "S": [ { "anything-but": [ "TOTAL" ] } ] } } } }'
             Architectures:
                 - arm64
             Environment:

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -713,6 +713,9 @@ Resources:
                         StartingPosition: TRIM_HORIZON
                         MaximumRetryAttempts: 5
                         ParallelizationFactor: 5
+                        FilterCriteria:
+                            Filters:
+                                - Pattern: '{ "dynamodb": { "Keys": { "pk": { "S": [ { "anything-but": [ "TOTAL" ] } ] } } } }'
             Architectures:
                 - arm64
             Environment:

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -540,7 +540,7 @@ Resources:
             CodeUri: ./functions/update-connections
             Description: Provides existing connections with relevant database updates
             Timeout: 10
-            MemorySize: 256
+            MemorySize: 512
             Layers:
                 - Ref: KeyphraseRepositoryLibraryLayer
                 - Ref: WebSocketClientLibraryLayer
@@ -700,7 +700,7 @@ Resources:
             Layers:
                 - Ref: KeyphraseRepositoryLibraryLayer
             Timeout: 10
-            MemorySize: 256
+            MemorySize: 1024
             Events:
                 KeyphraseStreamEvent:
                     Type: DynamoDB


### PR DESCRIPTION
# What

Optimised memory configuration of Update Connections and Total Occurrences lambda
Updated Update Connections and Total Occurrences lambda event mapping config to filter out global totals
Updated Update Connections batch size to 100 (Matches batch size on new connection lambda)

# Why

To improve the speed at which users receive results on the site

Appears to be two remaining slow downs:
- Increasing the batch size for total occurrences lambda results in an increase in DynamoDB write failures due to throttling. This actually would not be generally an issue if we:
    1. Only reported partial batch failures, currently the entire batch is retried (Pointless work)
    2. Retried failed writes with exponential backoff within the lambda
- Lambda is processing total rows as well as non-total:
    - The code actually ignores these rows, and new config has been added to ignore Global totals, however, if we could ignore both site and global totals at the event mapping level then the batches would only contain relevant events
        - Seems not possible to do unless changes were made to prefix non-total item SK with a constant
    - The event validation code could then be far simpler, just checking for non-global/site totals, disregarding everything else (It doesn't need to know what a global/site total is)

# Power Tuning Results

> Note each memory size was run against fifty times (batch size of 10 items) and the results were averaged to produce the below graphs

Update Connections:

![update-connections-power-tuning-results](https://user-images.githubusercontent.com/17100291/191037655-dc81026b-e4e9-4dd8-970b-7b11206223f7.png)

Total Occurrences:

I had to manually run this against each memory size sequentially to avoid transaction collisions:

| Memory Size (MB) | Time (ms) | Cost ($) |
| ------------------------- | ------------- | ----------- |
| 128 | 741 | 0.00000126 |
| 256 | 363 | 0.00000124 |
| 512 | 158 | 0.00000107 |
| 1024 | 83 | 0.00000113 |
| 2048 | 61 | 0.00000166 |



