### PR TITLE
Feature/334 query path occurrences

### DIFF
--- a/services/keyphrase/functions/query-keyphrases/adapters/QueryKeyphrasesAppSyncAdapter.ts
+++ b/services/keyphrase/functions/query-keyphrases/adapters/QueryKeyphrasesAppSyncAdapter.ts
@@ -24,6 +24,7 @@ class QueryKeyphrasesAppSyncAdapter
             );
 
             return keyphrases.map((item) => ({
+                __typename: "PathOccurrence",
                 id: `${baseURL}${pathname}#${item.keyphrase}`,
                 keyphrase: item.keyphrase,
                 occurrences: item.occurrences,
@@ -32,6 +33,7 @@ class QueryKeyphrasesAppSyncAdapter
 
         const keyphrases = await this.port.queryKeyphrases(baseURL);
         return keyphrases.map((item) => ({
+            __typename: "SiteOccurrence",
             id: `${baseURL}${item.pathname}#${item.keyphrase}`,
             keyphrase: item.keyphrase,
             pathname: item.pathname,

--- a/services/keyphrase/functions/query-keyphrases/adapters/QueryKeyphrasesAppSyncAdapter.ts
+++ b/services/keyphrase/functions/query-keyphrases/adapters/QueryKeyphrasesAppSyncAdapter.ts
@@ -16,8 +16,21 @@ class QueryKeyphrasesAppSyncAdapter
         event: AppSyncResolverEvent<QueryKeyphrasesArgs>
     ): Promise<KeyphraseOccurrence[]> {
         const baseURL = event.arguments.baseURL;
-        const keyphrases = await this.port.queryKeyphrases(baseURL);
+        const pathname = event.arguments.pathname;
+        if (pathname) {
+            const keyphrases = await this.port.queryKeyphrases(
+                baseURL,
+                pathname
+            );
 
+            return keyphrases.map((item) => ({
+                id: `${baseURL}${pathname}#${item.keyphrase}`,
+                keyphrase: item.keyphrase,
+                occurrences: item.occurrences,
+            }));
+        }
+
+        const keyphrases = await this.port.queryKeyphrases(baseURL);
         return keyphrases.map((item) => ({
             id: `${baseURL}${item.pathname}#${item.keyphrase}`,
             keyphrase: item.keyphrase,

--- a/services/keyphrase/functions/query-keyphrases/adapters/QueryKeyphrasesAppSyncAdapter.ts
+++ b/services/keyphrase/functions/query-keyphrases/adapters/QueryKeyphrasesAppSyncAdapter.ts
@@ -1,17 +1,20 @@
 import { AppSyncResolverEvent } from "aws-lambda";
 
-import { QueryKeyphrasesArgs, Keyphrase } from "../../../schemas/schema";
+import {
+    QueryKeyphrasesArgs,
+    KeyphraseOccurrence,
+} from "../../../schemas/schema";
 import AppSyncAdapter from "../interfaces/AppSyncAdapter";
 import { QueryKeyphrasesPort } from "../ports/QueryKeyphrasesPort";
 
 class QueryKeyphrasesAppSyncAdapter
-    implements AppSyncAdapter<QueryKeyphrasesArgs, Keyphrase[]>
+    implements AppSyncAdapter<QueryKeyphrasesArgs, KeyphraseOccurrence[]>
 {
     constructor(private port: QueryKeyphrasesPort) {}
 
     async handleQuery(
         event: AppSyncResolverEvent<QueryKeyphrasesArgs>
-    ): Promise<Keyphrase[]> {
+    ): Promise<KeyphraseOccurrence[]> {
         const baseURL = event.arguments.baseURL;
         const keyphrases = await this.port.queryKeyphrases(baseURL);
 

--- a/services/keyphrase/functions/query-keyphrases/adapters/__tests__/QueryKeyphrasesAppSyncAdapter.test.ts
+++ b/services/keyphrase/functions/query-keyphrases/adapters/__tests__/QueryKeyphrasesAppSyncAdapter.test.ts
@@ -88,6 +88,18 @@ describe.each([
             mockQueryKeyphrases.mockResolvedValue(stored);
         });
 
+        test("returns the typename for each object", async () => {
+            const actual = await adapter.handleQuery(VALID_BASE_URL_EVENT);
+
+            for (const item of actual) {
+                expect(item).toEqual(
+                    expect.objectContaining({
+                        __typename: "SiteOccurrence",
+                    })
+                );
+            }
+        });
+
         test("returns the base URL, path and keyphrase combined as unique ID for each object", async () => {
             const actual = await adapter.handleQuery(VALID_BASE_URL_EVENT);
 
@@ -187,6 +199,18 @@ describe.each([
     (message: string, stored: KeyphraseOccurrences[]) => {
         beforeEach(() => {
             mockQueryKeyphrases.mockResolvedValue(stored);
+        });
+
+        test("returns the typename for each object", async () => {
+            const actual = await adapter.handleQuery(VALID_PATH_EVENT);
+
+            for (const item of actual) {
+                expect(item).toEqual(
+                    expect.objectContaining({
+                        __typename: "PathOccurrence",
+                    })
+                );
+            }
         });
 
         test("returns the provided base URL, provided pathname, and keyphrase combined as unique ID for each object", async () => {

--- a/services/keyphrase/functions/query-keyphrases/adapters/__tests__/QueryKeyphrasesAppSyncAdapter.test.ts
+++ b/services/keyphrase/functions/query-keyphrases/adapters/__tests__/QueryKeyphrasesAppSyncAdapter.test.ts
@@ -4,6 +4,7 @@ import { On, method } from "ts-auto-mock/extension";
 import { AppSyncResolverEvent } from "aws-lambda";
 
 import {
+    KeyphraseOccurrences,
     PathKeyphraseOccurrences,
     QueryKeyphrasesPort,
 } from "../../ports/QueryKeyphrasesPort";
@@ -11,7 +12,9 @@ import QueryKeyphrasesAppSyncAdapter from "../QueryKeyphrasesAppSyncAdapter";
 import { QueryKeyphrasesArgs } from "../../../../schemas/schema";
 
 const VALID_BASE_URL = "www.example.com";
-const VALID_EVENT = createEvent(VALID_BASE_URL);
+const VALID_BASE_URL_EVENT = createEvent(VALID_BASE_URL);
+const VALID_PATHNAME = "/test";
+const VALID_PATH_EVENT = createEvent(VALID_BASE_URL, VALID_PATHNAME);
 
 const mockPort = createMock<QueryKeyphrasesPort>();
 const adapter = new QueryKeyphrasesAppSyncAdapter(mockPort);
@@ -20,11 +23,13 @@ const mockQueryKeyphrases: jest.Mock = On(mockPort).get(
 );
 
 function createEvent(
-    baseURL: string
+    baseURL: string,
+    pathname?: string
 ): AppSyncResolverEvent<QueryKeyphrasesArgs> {
     const event = mock<AppSyncResolverEvent<QueryKeyphrasesArgs>>();
     event.arguments = {
-        baseURL: baseURL,
+        baseURL,
+        pathname,
     };
 
     return event;
@@ -37,19 +42,28 @@ beforeEach(() => {
 test("calls the port with the provided base URL", async () => {
     mockQueryKeyphrases.mockResolvedValue([]);
 
-    await adapter.handleQuery(VALID_EVENT);
+    await adapter.handleQuery(VALID_BASE_URL_EVENT);
 
     expect(mockPort.queryKeyphrases).toHaveBeenCalledTimes(1);
     expect(mockPort.queryKeyphrases).toHaveBeenCalledWith(VALID_BASE_URL);
 });
 
-test("returns empty array if no keyphrases returned", async () => {
-    mockQueryKeyphrases.mockResolvedValue([]);
+test.each([
+    ["provided base URL", VALID_BASE_URL_EVENT],
+    ["provided pathname", VALID_PATH_EVENT],
+])(
+    "returns empty array if no keyphrases returned for %s",
+    async (
+        message: string,
+        event: AppSyncResolverEvent<QueryKeyphrasesArgs>
+    ) => {
+        mockQueryKeyphrases.mockResolvedValue([]);
 
-    const actual = await adapter.handleQuery(VALID_EVENT);
+        const actual = await adapter.handleQuery(event);
 
-    expect(actual).toEqual([]);
-});
+        expect(actual).toEqual([]);
+    }
+);
 
 describe.each([
     [
@@ -68,14 +82,14 @@ describe.each([
         ],
     ],
 ])(
-    "response mapping given %s",
+    "overall base URL response mapping given %s",
     (message: string, stored: PathKeyphraseOccurrences[]) => {
         beforeEach(() => {
             mockQueryKeyphrases.mockResolvedValue(stored);
         });
 
         test("returns the base URL, path and keyphrase combined as unique ID for each object", async () => {
-            const actual = await adapter.handleQuery(VALID_EVENT);
+            const actual = await adapter.handleQuery(VALID_BASE_URL_EVENT);
 
             for (const item of stored) {
                 const expectedID = `${VALID_BASE_URL}${item.pathname}#${item.keyphrase}`;
@@ -88,7 +102,7 @@ describe.each([
         });
 
         test("returns the actual keyphrase analyzed on provided base URL for each occurrence returned", async () => {
-            const actual = await adapter.handleQuery(VALID_EVENT);
+            const actual = await adapter.handleQuery(VALID_BASE_URL_EVENT);
 
             for (const item of stored) {
                 expect(actual).toContainEqual(
@@ -100,7 +114,7 @@ describe.each([
         });
 
         test("returns the number of occurrences each keyphrase returned was found on provided base URL", async () => {
-            const actual = await adapter.handleQuery(VALID_EVENT);
+            const actual = await adapter.handleQuery(VALID_BASE_URL_EVENT);
 
             for (const item of stored) {
                 expect(actual).toContainEqual(
@@ -112,7 +126,7 @@ describe.each([
         });
 
         test("returns the path each keyphrase returned was found on provided base URL", async () => {
-            const actual = await adapter.handleQuery(VALID_EVENT);
+            const actual = await adapter.handleQuery(VALID_BASE_URL_EVENT);
 
             for (const item of stored) {
                 expect(actual).toContainEqual(
@@ -125,12 +139,91 @@ describe.each([
     }
 );
 
-test("throws an error if an unexpected error occurs getting the keyphrases for a provided base URL", async () => {
-    const expectedError = new Error("test error");
-    mockQueryKeyphrases.mockRejectedValue(expectedError);
+test.each([
+    ["provided base URL", VALID_BASE_URL_EVENT],
+    ["provided pathname", VALID_PATH_EVENT],
+])(
+    "throws an error if an unexpected error occurs getting the keyphrases for %s",
+    async (
+        message: string,
+        event: AppSyncResolverEvent<QueryKeyphrasesArgs>
+    ) => {
+        const expectedError = new Error("test error");
+        mockQueryKeyphrases.mockRejectedValue(expectedError);
 
-    expect.assertions(1);
-    await expect(adapter.handleQuery(VALID_EVENT)).rejects.toThrowError(
-        expectedError
+        expect.assertions(1);
+        await expect(adapter.handleQuery(event)).rejects.toThrowError(
+            expectedError
+        );
+    }
+);
+
+test("only queries port for specific path if provided", async () => {
+    mockQueryKeyphrases.mockResolvedValue([]);
+
+    await adapter.handleQuery(VALID_PATH_EVENT);
+
+    expect(mockPort.queryKeyphrases).toHaveBeenCalledTimes(1);
+    expect(mockPort.queryKeyphrases).toHaveBeenCalledWith(
+        VALID_BASE_URL,
+        VALID_PATHNAME
     );
 });
+
+describe.each([
+    ["a single keyphrase stored", [{ keyphrase: "wibble", occurrences: 15 }]],
+    [
+        "multiple keyphrases stored",
+        [
+            { keyphrase: "wibble", occurrences: 15 },
+            {
+                keyphrase: "dyson sphere",
+                occurrences: 11,
+            },
+        ],
+    ],
+])(
+    "individual path response mapping given %s",
+    (message: string, stored: KeyphraseOccurrences[]) => {
+        beforeEach(() => {
+            mockQueryKeyphrases.mockResolvedValue(stored);
+        });
+
+        test("returns the provided base URL, provided pathname, and keyphrase combined as unique ID for each object", async () => {
+            const actual = await adapter.handleQuery(VALID_PATH_EVENT);
+
+            for (const item of stored) {
+                const expectedID = `${VALID_BASE_URL}${VALID_PATHNAME}#${item.keyphrase}`;
+                expect(actual).toContainEqual(
+                    expect.objectContaining({
+                        id: expectedID,
+                    })
+                );
+            }
+        });
+
+        test("returns the actual keyphrase analyzed on provided base URL for each occurrence returned", async () => {
+            const actual = await adapter.handleQuery(VALID_PATH_EVENT);
+
+            for (const item of stored) {
+                expect(actual).toContainEqual(
+                    expect.objectContaining({
+                        keyphrase: item.keyphrase,
+                    })
+                );
+            }
+        });
+
+        test("returns the number of occurrences each keyphrase returned was found on provided base URL", async () => {
+            const actual = await adapter.handleQuery(VALID_PATH_EVENT);
+
+            for (const item of stored) {
+                expect(actual).toContainEqual(
+                    expect.objectContaining({
+                        occurrences: item.occurrences,
+                    })
+                );
+            }
+        });
+    }
+);

--- a/services/keyphrase/functions/query-keyphrases/domain/QueryKeyphrasesDomain.ts
+++ b/services/keyphrase/functions/query-keyphrases/domain/QueryKeyphrasesDomain.ts
@@ -1,6 +1,7 @@
 import { Repository } from "buzzword-keyphrase-keyphrase-repository-library";
 
 import {
+    KeyphraseOccurrences,
     PathKeyphraseOccurrences,
     QueryKeyphrasesPort,
 } from "../ports/QueryKeyphrasesPort";
@@ -10,10 +11,29 @@ const INVALID_BASE_URL_ERROR = "Invalid base URL provided.";
 class QueryKeyphrasesDomain implements QueryKeyphrasesPort {
     constructor(private repository: Repository) {}
 
+    queryKeyphrases(baseURL: string): Promise<PathKeyphraseOccurrences[]>;
+    queryKeyphrases(
+        baseURL: string,
+        pathname: string
+    ): Promise<KeyphraseOccurrences[]>;
+
     async queryKeyphrases(
-        baseURL: string
-    ): Promise<PathKeyphraseOccurrences[]> {
+        baseURL: string,
+        pathname?: string
+    ): Promise<PathKeyphraseOccurrences[] | KeyphraseOccurrences[]> {
         const validatedURL = this.validateURL(baseURL);
+        if (pathname) {
+            const stored = await this.repository.getOccurrences(
+                validatedURL.hostname,
+                pathname
+            );
+
+            return stored.map((item) => ({
+                keyphrase: item.keyphrase,
+                occurrences: item.occurrences,
+            }));
+        }
+
         const stored = await this.repository.getOccurrences(
             validatedURL.hostname
         );

--- a/services/keyphrase/functions/query-keyphrases/domain/__tests__/QueryKeyphrasesDomain.test.ts
+++ b/services/keyphrase/functions/query-keyphrases/domain/__tests__/QueryKeyphrasesDomain.test.ts
@@ -26,7 +26,7 @@ describe.each([
     ["invalid base URL (space)", "invalid base URL"],
 ])("invalid base URL handling given %s", (message: string, input: string) => {
     test("throws an invalid input error", async () => {
-        const expectedErrorMessage = "Invalid base URL provided.";
+        const expectedErrorMessage = "Invalid URL provided.";
 
         expect.assertions(1);
         await expect(domain.queryKeyphrases(input)).rejects.toThrowError(
@@ -138,6 +138,28 @@ test("throws an error if an unexpected error occurs getting the keyphrases for a
     ).rejects.toThrowError(expectedError);
 });
 
+describe("invalid pathname handling given a path with a missing forward slash", () => {
+    const pathname = "test";
+    test("throws an invalid input error", async () => {
+        const expectedErrorMessage = "Invalid URL provided.";
+
+        expect.assertions(1);
+        await expect(
+            domain.queryKeyphrases(EXPECTED_BASE_URL, pathname)
+        ).rejects.toThrowError(expectedErrorMessage);
+    });
+
+    test("does not call port to get keyphrases", async () => {
+        try {
+            await domain.queryKeyphrases(EXPECTED_BASE_URL, pathname);
+        } catch {
+            // Expected Error
+        }
+
+        expect(mockRepository.getOccurrences).not.toHaveBeenCalled();
+    });
+});
+
 test("calls repository to get keyphrases on given path of URL", async () => {
     mockGetOccurrences.mockResolvedValue([]);
 
@@ -208,3 +230,13 @@ test.each([
         expect(actual).toEqual(expected);
     }
 );
+
+test("throws an error if an unexpected error occurs getting the keyphrases for a provided path", async () => {
+    const expectedError = new Error("test error");
+    mockGetOccurrences.mockRejectedValue(expectedError);
+
+    expect.assertions(1);
+    await expect(
+        domain.queryKeyphrases(EXPECTED_BASE_URL, EXPECTED_PATH)
+    ).rejects.toThrowError(expectedError);
+});

--- a/services/keyphrase/functions/query-keyphrases/ports/QueryKeyphrasesPort.ts
+++ b/services/keyphrase/functions/query-keyphrases/ports/QueryKeyphrasesPort.ts
@@ -1,11 +1,18 @@
-type PathKeyphraseOccurrences = {
+type KeyphraseOccurrences = {
     keyphrase: string;
-    pathname: string;
     occurrences: number;
+};
+
+type PathKeyphraseOccurrences = KeyphraseOccurrences & {
+    pathname: string;
 };
 
 interface QueryKeyphrasesPort {
     queryKeyphrases(baseURL: string): Promise<PathKeyphraseOccurrences[]>;
+    queryKeyphrases(
+        baseURL: string,
+        pathname: string
+    ): Promise<KeyphraseOccurrences[]>;
 }
 
-export { PathKeyphraseOccurrences, QueryKeyphrasesPort };
+export { KeyphraseOccurrences, PathKeyphraseOccurrences, QueryKeyphrasesPort };

--- a/services/keyphrase/functions/query-keyphrases/query-keyphrases.ts
+++ b/services/keyphrase/functions/query-keyphrases/query-keyphrases.ts
@@ -4,7 +4,7 @@ import {
     KeyphraseRepository,
 } from "buzzword-keyphrase-keyphrase-repository-library";
 
-import { Keyphrase, QueryKeyphrasesArgs } from "../../schemas/schema";
+import { KeyphraseOccurrence, QueryKeyphrasesArgs } from "../../schemas/schema";
 import QueryKeyphrasesAppSyncAdapter from "./adapters/QueryKeyphrasesAppSyncAdapter";
 import QueryKeyphrasesDomain from "./domain/QueryKeyphrasesDomain";
 
@@ -22,7 +22,7 @@ const adapter = new QueryKeyphrasesAppSyncAdapter(domain);
 
 async function handler(
     event: AppSyncResolverEvent<QueryKeyphrasesArgs>
-): Promise<Keyphrase[]> {
+): Promise<KeyphraseOccurrence[]> {
     return adapter.handleQuery(event);
 }
 

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -710,6 +710,8 @@ Resources:
             Description: Enables queries against keyphrases analyzed on websites
             Layers:
                 - Ref: KeyphraseRepositoryLibraryLayer
+            Timeout: 8
+            MemorySize: 1536
             Architectures:
                 - arm64
             Environment:
@@ -767,7 +769,7 @@ Resources:
                     "version": "2017-02-28",
                     "operation": "Invoke",
                     "payload": {
-                        "field": "urls",
+                        "field": "keyphrases",
                         "arguments": $utils.toJson($context.arguments)
                     }
                 }

--- a/services/keyphrase/schemas/schema.graphql
+++ b/services/keyphrase/schemas/schema.graphql
@@ -3,7 +3,7 @@ schema {
 }
 
 type Query {
-    keyphrases(baseURL: ID!): [KeyphraseOccurrence]!
+    keyphrases(baseURL: ID!, pathname: String): [KeyphraseOccurrence]!
 }
 
 interface Node {

--- a/services/keyphrase/schemas/schema.graphql
+++ b/services/keyphrase/schemas/schema.graphql
@@ -11,6 +11,7 @@ interface Node {
 }
 
 interface KeyphraseOccurrence {
+    id: ID!
     keyphrase: String!
     occurrences: Int!
 }

--- a/services/keyphrase/schemas/schema.graphql
+++ b/services/keyphrase/schemas/schema.graphql
@@ -3,16 +3,27 @@ schema {
 }
 
 type Query {
-    keyphrases(baseURL: ID!): [Keyphrase]!
+    keyphrases(baseURL: ID!): [KeyphraseOccurrence]!
 }
 
 interface Node {
     id: ID!
 }
 
-type Keyphrase implements Node {
+interface KeyphraseOccurrence {
+    keyphrase: String!
+    occurrences: Int!
+}
+
+type SiteOccurrence implements Node & KeyphraseOccurrence {
     id: ID!
     pathname: String!
+    keyphrase: String!
+    occurrences: Int!
+}
+
+type PathOccurrence implements Node & KeyphraseOccurrence {
+    id: ID!
     keyphrase: String!
     occurrences: Int!
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -29,7 +29,7 @@
                 "@babel/preset-env": "^7.18.2",
                 "@babel/preset-react": "^7.17.12",
                 "@babel/preset-typescript": "^7.17.12",
-                "@playwright/experimental-ct-react": "^1.26.1",
+                "@playwright/experimental-ct-react": "^1.27.1",
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^13.3.0",
                 "@types/react": "^18.0.9",
@@ -4279,12 +4279,12 @@
             "optional": true
         },
         "node_modules/@playwright/experimental-ct-react": {
-            "version": "1.26.1",
-            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.26.1.tgz",
-            "integrity": "sha512-SBuzT/fCBxAtCnT4shi29Dyej6GwL1E5rr9LxH2bXRkWbrm1UmewZxKDDEQ4WbC9TjE2T2+GJz0uBiM48m6kzQ==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.27.1.tgz",
+            "integrity": "sha512-uY6nWEuOA2jWHIsf+mKSctwzGWkKuTKd/VdHo6Gr0ACsVUTFul770bK4HVcV+GBgjZhzj2hUmCCzB29j7jvUNA==",
             "dev": true,
             "dependencies": {
-                "@playwright/test": "1.26.1",
+                "@playwright/test": "1.27.1",
                 "@vitejs/plugin-react": "^2.0.1",
                 "vite": "^3.0.9"
             },
@@ -4293,13 +4293,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.26.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-            "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+            "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "playwright-core": "1.26.1"
+                "playwright-core": "1.27.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14271,9 +14271,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.26.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-            "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+            "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
             "dev": true,
             "bin": {
                 "playwright": "cli.js"
@@ -21683,24 +21683,24 @@
             "optional": true
         },
         "@playwright/experimental-ct-react": {
-            "version": "1.26.1",
-            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.26.1.tgz",
-            "integrity": "sha512-SBuzT/fCBxAtCnT4shi29Dyej6GwL1E5rr9LxH2bXRkWbrm1UmewZxKDDEQ4WbC9TjE2T2+GJz0uBiM48m6kzQ==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.27.1.tgz",
+            "integrity": "sha512-uY6nWEuOA2jWHIsf+mKSctwzGWkKuTKd/VdHo6Gr0ACsVUTFul770bK4HVcV+GBgjZhzj2hUmCCzB29j7jvUNA==",
             "dev": true,
             "requires": {
-                "@playwright/test": "1.26.1",
+                "@playwright/test": "1.27.1",
                 "@vitejs/plugin-react": "^2.0.1",
                 "vite": "^3.0.9"
             }
         },
         "@playwright/test": {
-            "version": "1.26.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.26.1.tgz",
-            "integrity": "sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.27.1.tgz",
+            "integrity": "sha512-mrL2q0an/7tVqniQQF6RBL2saskjljXzqNcCOVMUjRIgE6Y38nCNaP+Dc2FBW06bcpD3tqIws/HT9qiMHbNU0A==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
-                "playwright-core": "1.26.1"
+                "playwright-core": "1.27.1"
             }
         },
         "@react-native-community/cli-clean": {
@@ -29355,9 +29355,9 @@
             }
         },
         "playwright-core": {
-            "version": "1.26.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.26.1.tgz",
-            "integrity": "sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==",
+            "version": "1.27.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.27.1.tgz",
+            "integrity": "sha512-9EmeXDncC2Pmp/z+teoVYlvmPWUC6ejSSYZUln7YaP89Z6lpAaiaAnqroUt/BoLo8tn7WYShcfaCh+xofZa44Q==",
             "dev": true
         },
         "plist": {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -255,9 +255,9 @@
             }
         },
         "node_modules/@antv/g2": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-4.2.6.tgz",
-            "integrity": "sha512-mg3r+U9GqOU4aqosSUll5srEgOZxgl8WZ5Z6+9gH0ewaUGusvy2MUm6vEMyrp+VBoU0R/fOGv/3EuqRhT7+cgg==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-4.2.8.tgz",
+            "integrity": "sha512-V2ntdehdCTCjSdkDxC1/kafii/2MZ2dhLd/auMoE6viwIvyy5CKkd7qa9krxJ4IIR5RH9v5uoRV8q2Bzd0OD2Q==",
             "dependencies": {
                 "@antv/adjust": "^0.2.1",
                 "@antv/attr": "^0.3.1",
@@ -277,9 +277,9 @@
             }
         },
         "node_modules/@antv/g2plot": {
-            "version": "2.4.20",
-            "resolved": "https://registry.npmjs.org/@antv/g2plot/-/g2plot-2.4.20.tgz",
-            "integrity": "sha512-MHFTe3zdEHy/5VHdG9LmX9jQy9NdZm31olQjhE65eGpxhX5N1ibyo+qO247I9Jazb4sLD5LNWYPtPHofUOUaNg==",
+            "version": "2.4.22",
+            "resolved": "https://registry.npmjs.org/@antv/g2plot/-/g2plot-2.4.22.tgz",
+            "integrity": "sha512-wwpSJ9TL1Z4f35dnlT4wy2z24T38xb8qvb+a9thC/FUx4Iu04zc5vqGOqNvDlBRZAq53+KOMRJ7eC5XtsT8QIg==",
             "dependencies": {
                 "@antv/event-emitter": "^0.1.2",
                 "@antv/g2": "^4.1.26",
@@ -12479,9 +12479,9 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
@@ -18584,9 +18584,9 @@
             }
         },
         "@antv/g2": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-4.2.6.tgz",
-            "integrity": "sha512-mg3r+U9GqOU4aqosSUll5srEgOZxgl8WZ5Z6+9gH0ewaUGusvy2MUm6vEMyrp+VBoU0R/fOGv/3EuqRhT7+cgg==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/@antv/g2/-/g2-4.2.8.tgz",
+            "integrity": "sha512-V2ntdehdCTCjSdkDxC1/kafii/2MZ2dhLd/auMoE6viwIvyy5CKkd7qa9krxJ4IIR5RH9v5uoRV8q2Bzd0OD2Q==",
             "requires": {
                 "@antv/adjust": "^0.2.1",
                 "@antv/attr": "^0.3.1",
@@ -18606,9 +18606,9 @@
             }
         },
         "@antv/g2plot": {
-            "version": "2.4.20",
-            "resolved": "https://registry.npmjs.org/@antv/g2plot/-/g2plot-2.4.20.tgz",
-            "integrity": "sha512-MHFTe3zdEHy/5VHdG9LmX9jQy9NdZm31olQjhE65eGpxhX5N1ibyo+qO247I9Jazb4sLD5LNWYPtPHofUOUaNg==",
+            "version": "2.4.22",
+            "resolved": "https://registry.npmjs.org/@antv/g2plot/-/g2plot-2.4.22.tgz",
+            "integrity": "sha512-wwpSJ9TL1Z4f35dnlT4wy2z24T38xb8qvb+a9thC/FUx4Iu04zc5vqGOqNvDlBRZAq53+KOMRJ7eC5XtsT8QIg==",
             "requires": {
                 "@antv/event-emitter": "^0.1.2",
                 "@antv/g2": "^4.1.26",
@@ -27959,9 +27959,9 @@
             "dev": true
         },
         "loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+            "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
-        "@playwright/experimental-ct-react": "^1.26.1",
+        "@playwright/experimental-ct-react": "^1.27.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/react": "^18.0.9",


### PR DESCRIPTION
# What

Update keyphrase service GraphQL schema to add optional pathname argument to keyphrase query
Update Query Keyphrase lambda to handle queries for keyphrases found on specific pathname
Updated keyphrase service template with optimised query keyphrase lambda memory size

# Why

To enable clients of the keyphrase service to retrieve only keyphrase results related to a given path rather than having to obtain the entire site's results

# Power tuning results

Overall site (No path provided):

![Overall site results](https://user-images.githubusercontent.com/17100291/200633275-c903c6b0-2c69-4dca-b07a-872a15b2c3cb.png)

Single path:

![Single path results](https://user-images.githubusercontent.com/17100291/200633356-b57a3120-1ee5-4b41-85d9-69613a2874f0.png)
