### PR TITLE
fix/ci python version warning

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -169,6 +169,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.8"
             - uses: actions/setup-node@v3
               with:
                   node-version: "16"

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -145,6 +145,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.8"
             - uses: actions/setup-node@v3
               with:
                   node-version: "16"


### PR DESCRIPTION
# What

Update usages of setup-python action to provide static python version

# Why

To pin to particular python version, removing possibility of failures being introduced by new versions