### PR TITLE
Feature/458 retain page structure

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -25,3 +25,7 @@ schema.d.ts
 test-results/
 playwright-report/
 **/playwright/.cache/
+
+# Test Assets
+
+whitespace.html

--- a/services/keyphrase/functions/scrape-url/adapters/HTMLParser.ts
+++ b/services/keyphrase/functions/scrape-url/adapters/HTMLParser.ts
@@ -9,7 +9,7 @@ class HTMLParser implements HTMLParsingProvider {
                 noSourceImageFormatter: function (elem, _walk, builder) {
                     const attribs = elem.attribs || {};
                     if (attribs.alt) {
-                        builder.addInline(attribs.alt);
+                        builder.addInline(`${attribs.alt} `);
                     }
                 },
             },

--- a/services/keyphrase/functions/scrape-url/adapters/HTMLParser.ts
+++ b/services/keyphrase/functions/scrape-url/adapters/HTMLParser.ts
@@ -4,7 +4,28 @@ import HTMLParsingProvider from "../ports/HTMLParsingProvider";
 
 class HTMLParser implements HTMLParsingProvider {
     parseHTML(html: string): string {
-        return convert(html);
+        return convert(html, {
+            formatters: {
+                noSourceImageFormatter: function (elem, _walk, builder) {
+                    const attribs = elem.attribs || {};
+                    if (attribs.alt) {
+                        builder.addInline(attribs.alt);
+                    }
+                },
+            },
+            selectors: [
+                {
+                    selector: "a",
+                    options: {
+                        ignoreHref: true,
+                    },
+                },
+                {
+                    selector: "img",
+                    format: "noSourceImageFormatter",
+                },
+            ],
+        });
     }
 }
 

--- a/services/keyphrase/functions/scrape-url/adapters/HTMLParser.ts
+++ b/services/keyphrase/functions/scrape-url/adapters/HTMLParser.ts
@@ -1,41 +1,10 @@
-import { Parser } from "htmlparser2";
+import { convert } from "html-to-text";
 
 import HTMLParsingProvider from "../ports/HTMLParsingProvider";
 
-enum UnparsableElements {
-    Script = "script",
-    Style = "style",
-}
-
 class HTMLParser implements HTMLParsingProvider {
     parseHTML(html: string): string {
-        let completeText = "";
-        let skip = false;
-        const parser = new Parser({
-            onopentag: (name) => {
-                const unparsable: string[] = Object.values(UnparsableElements);
-                skip = unparsable.includes(name);
-            },
-            ontext: (text) => {
-                if (!skip) {
-                    completeText = `${completeText} ${this.removeExtraWhitespace(
-                        text
-                    )}`;
-                }
-            },
-        });
-
-        parser.write(html);
-        parser.end();
-        return this.removeSpecialCharacters(completeText).trim();
-    }
-
-    private removeExtraWhitespace(text: string): string {
-        return text.replace(/\s+/g, " ");
-    }
-
-    private removeSpecialCharacters(text: string): string {
-        return text.replace(/\n|\r|\t/g, "");
+        return convert(html);
     }
 }
 

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/HTMLParser.test.ts
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/HTMLParser.test.ts
@@ -96,3 +96,13 @@ test("adds no text if no image alt available", () => {
 
     expect(result).toEqual("No image alt provided");
 });
+
+test("adds whitespace between images alt texts on same line", () => {
+    const html = readFile(
+        path.join(ASSET_FOLDER, "multi-img-alt-same-line.html")
+    );
+
+    const result = parser.parseHTML(html);
+
+    expect(result).toEqual("First Second");
+});

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/HTMLParser.test.ts
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/HTMLParser.test.ts
@@ -62,3 +62,13 @@ test.each([
 
     expect(result).toEqual("This is actual text!");
 });
+
+test("returns text with structure respected given multiple paragraphs", () => {
+    const html = readFile(path.join(ASSET_FOLDER, "multi-paragraph.html"));
+
+    const result = parser.parseHTML(html);
+
+    expect(result).toEqual(
+        `First paragraph\n\nSecond paragraph\n\nThird paragraph`
+    );
+});

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/HTMLParser.test.ts
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/HTMLParser.test.ts
@@ -69,6 +69,30 @@ test("returns text with structure respected given multiple paragraphs", () => {
     const result = parser.parseHTML(html);
 
     expect(result).toEqual(
-        `First paragraph\n\nSecond paragraph\n\nThird paragraph`
+        "First paragraph\n\nSecond paragraph\n\nThird paragraph"
     );
+});
+
+test("ignores href of any links in page", () => {
+    const html = readFile(path.join(ASSET_FOLDER, "link.html"));
+
+    const result = parser.parseHTML(html);
+
+    expect(result).toEqual("Ignores href text");
+});
+
+test("ignores src of any image on page", () => {
+    const html = readFile(path.join(ASSET_FOLDER, "image-source.html"));
+
+    const result = parser.parseHTML(html);
+
+    expect(result).toEqual("Ignores image source");
+});
+
+test("adds no text if no image alt available", () => {
+    const html = readFile(path.join(ASSET_FOLDER, "no-image-alt.html"));
+
+    const result = parser.parseHTML(html);
+
+    expect(result).toEqual("No image alt provided");
 });

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/image-source.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/image-source.html
@@ -1,9 +1,6 @@
 <!DOCTYPE html>
 <html>
     <body>
-        <img src="test.png" alt="Ignores image source" /><img
-            src="test.png"
-            alt="Ignores image source"
-        />
+        <img src="test.png" alt="Ignores image source" />
     </body>
 </html>

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/image-source.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/image-source.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <img src="test.png" alt="Ignores image source" /><img
+            src="test.png"
+            alt="Ignores image source"
+        />
+    </body>
+</html>

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/link.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/link.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <a href="https://www.text.com/">Ignores href text</a>
+    </body>
+</html>

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/multi-img-alt-same-line.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/multi-img-alt-same-line.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <img src="test.png" alt="First" /><img src="test.png" alt="Second" />
+    </body>
+</html>

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/multi-paragraph.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/multi-paragraph.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <p>First paragraph</p>
+        <p>Second paragraph</p>
+        <p>Third paragraph</p>
+    </body>
+</html>

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/no-image-alt.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/no-image-alt.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <img src="test.png" />
+        <p>No image alt provided</p>
+    </body>
+</html>

--- a/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/whitespace.html
+++ b/services/keyphrase/functions/scrape-url/adapters/__tests__/assets/whitespace.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
     <body>
-        <p>Added Whitespace Between Words</p>
+        <p>Added              Whitespace               Between                      Words</p>
     </body>
 </html>

--- a/services/keyphrase/functions/scrape-url/package-lock.json
+++ b/services/keyphrase/functions/scrape-url/package-lock.json
@@ -9,7 +9,10 @@
             "version": "1.0.0",
             "dependencies": {
                 "@ashley-evans/buzzword-crawl-client": "1.0.0",
-                "htmlparser2": "8.0.1"
+                "html-to-text": "8.2.1"
+            },
+            "devDependencies": {
+                "@types/html-to-text": "^8.1.1"
             }
         },
         "node_modules/@ashley-evans/buzzword-crawl-client": {
@@ -19,6 +22,38 @@
             "peerDependencies": {
                 "axios": "^0.27.2"
             }
+        },
+        "node_modules/@selderee/plugin-htmlparser2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
+            "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
+            "dependencies": {
+                "domhandler": "^4.2.0",
+                "selderee": "^0.6.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
+            }
+        },
+        "node_modules/@selderee/plugin-htmlparser2/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/@types/html-to-text": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-8.1.1.tgz",
+            "integrity": "sha512-QFcqfc7TiVbvIX8Fc2kWUxakruI1Ay6uitaGCYHzI5M0WHQROV5D2XeSaVrK0FmvssivXum4yERVnJsiuH61Ww==",
+            "dev": true
         },
         "node_modules/asynckit": {
             "version": "0.4.0",
@@ -48,6 +83,19 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -57,18 +105,10 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
+        "node_modules/discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
         "node_modules/domelementtype": {
             "version": "2.3.0",
@@ -80,44 +120,6 @@
                     "url": "https://github.com/sponsors/fb55"
                 }
             ]
-        },
-        "node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/entities": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-            "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
         },
         "node_modules/follow-redirects": {
             "version": "1.15.2",
@@ -153,10 +155,85 @@
                 "node": ">= 6"
             }
         },
-        "node_modules/htmlparser2": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/html-to-text": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
+            "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
+            "dependencies": {
+                "@selderee/plugin-htmlparser2": "^0.6.0",
+                "deepmerge": "^4.2.2",
+                "he": "^1.2.0",
+                "htmlparser2": "^6.1.0",
+                "minimist": "^1.2.6",
+                "selderee": "^0.6.0"
+            },
+            "bin": {
+                "html-to-text": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10.23.2"
+            }
+        },
+        "node_modules/html-to-text/node_modules/dom-serializer": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+            "dependencies": {
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.2.0",
+                "entities": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/html-to-text/node_modules/domhandler": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+            "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+            "dependencies": {
+                "domelementtype": "^2.2.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/html-to-text/node_modules/domutils": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+            "dependencies": {
+                "dom-serializer": "^1.0.1",
+                "domelementtype": "^2.2.0",
+                "domhandler": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/html-to-text/node_modules/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/html-to-text/node_modules/htmlparser2": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+            "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
             "funding": [
                 "https://github.com/fb55/htmlparser2?sponsor=1",
                 {
@@ -165,10 +242,10 @@
                 }
             ],
             "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "entities": "^4.3.0"
+                "domelementtype": "^2.0.1",
+                "domhandler": "^4.0.0",
+                "domutils": "^2.5.2",
+                "entities": "^2.0.0"
             }
         },
         "node_modules/mime-db": {
@@ -191,6 +268,88 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/moo": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+            "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+        },
+        "node_modules/nearley": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+            "dependencies": {
+                "commander": "^2.19.0",
+                "moo": "^0.5.0",
+                "railroad-diagrams": "^1.0.0",
+                "randexp": "0.4.6"
+            },
+            "bin": {
+                "nearley-railroad": "bin/nearley-railroad.js",
+                "nearley-test": "bin/nearley-test.js",
+                "nearley-unparse": "bin/nearley-unparse.js",
+                "nearleyc": "bin/nearleyc.js"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://nearley.js.org/#give-to-nearley"
+            }
+        },
+        "node_modules/parseley": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
+            "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
+            "dependencies": {
+                "moo": "^0.5.1",
+                "nearley": "^2.20.1"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
+            }
+        },
+        "node_modules/railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+        },
+        "node_modules/randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "dependencies": {
+                "discontinuous-range": "1.0.0",
+                "ret": "~0.1.10"
+            },
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "engines": {
+                "node": ">=0.12"
+            }
+        },
+        "node_modules/selderee": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
+            "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
+            "dependencies": {
+                "parseley": "^0.7.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/killymxi"
+            }
         }
     },
     "dependencies": {
@@ -199,6 +358,31 @@
             "resolved": "https://npm.pkg.github.com/download/@ashley-evans/buzzword-crawl-client/1.0.0/3675496b36411d1aad9420152e135f89be39397d",
             "integrity": "sha512-+duVdF4DLB9X/T8vPQeFsSpc4v1zWUSUSIuzoDoMApUymus8dz3A3P5mJcWHdZpIsALFLES83V4GHWCx0r6X5A==",
             "requires": {}
+        },
+        "@selderee/plugin-htmlparser2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
+            "integrity": "sha512-J3jpy002TyBjd4N/p6s+s90eX42H2eRhK3SbsZuvTDv977/E8p2U3zikdiehyJja66do7FlxLomZLPlvl2/xaA==",
+            "requires": {
+                "domhandler": "^4.2.0",
+                "selderee": "^0.6.0"
+            },
+            "dependencies": {
+                "domhandler": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+                    "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+                    "requires": {
+                        "domelementtype": "^2.2.0"
+                    }
+                }
+            }
+        },
+        "@types/html-to-text": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-8.1.1.tgz",
+            "integrity": "sha512-QFcqfc7TiVbvIX8Fc2kWUxakruI1Ay6uitaGCYHzI5M0WHQROV5D2XeSaVrK0FmvssivXum4yERVnJsiuH61Ww==",
+            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
@@ -225,49 +409,31 @@
                 "delayed-stream": "~1.0.0"
             }
         },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+        },
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
             "peer": true
         },
-        "dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "requires": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            }
+        "discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ=="
         },
         "domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-        },
-        "domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "requires": {
-                "domelementtype": "^2.3.0"
-            }
-        },
-        "domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-            "requires": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
-            }
-        },
-        "entities": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-            "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
         },
         "follow-redirects": {
             "version": "1.15.2",
@@ -286,15 +452,68 @@
                 "mime-types": "^2.1.12"
             }
         },
-        "htmlparser2": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+        "he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        },
+        "html-to-text": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-8.2.1.tgz",
+            "integrity": "sha512-aN/3JvAk8qFsWVeE9InWAWueLXrbkoVZy0TkzaGhoRBC2gCFEeRLDDJN3/ijIGHohy6H+SZzUQWN/hcYtaPK8w==",
             "requires": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "entities": "^4.3.0"
+                "@selderee/plugin-htmlparser2": "^0.6.0",
+                "deepmerge": "^4.2.2",
+                "he": "^1.2.0",
+                "htmlparser2": "^6.1.0",
+                "minimist": "^1.2.6",
+                "selderee": "^0.6.0"
+            },
+            "dependencies": {
+                "dom-serializer": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+                    "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+                    "requires": {
+                        "domelementtype": "^2.0.1",
+                        "domhandler": "^4.2.0",
+                        "entities": "^2.0.0"
+                    }
+                },
+                "domhandler": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+                    "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+                    "requires": {
+                        "domelementtype": "^2.2.0"
+                    }
+                },
+                "domutils": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+                    "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+                    "requires": {
+                        "dom-serializer": "^1.0.1",
+                        "domelementtype": "^2.2.0",
+                        "domhandler": "^4.2.0"
+                    }
+                },
+                "entities": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+                    "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+                },
+                "htmlparser2": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+                    "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+                    "requires": {
+                        "domelementtype": "^2.0.1",
+                        "domhandler": "^4.0.0",
+                        "domutils": "^2.5.2",
+                        "entities": "^2.0.0"
+                    }
+                }
             }
         },
         "mime-db": {
@@ -310,6 +529,63 @@
             "peer": true,
             "requires": {
                 "mime-db": "1.52.0"
+            }
+        },
+        "minimist": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+            "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+        },
+        "moo": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+            "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
+        },
+        "nearley": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+            "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+            "requires": {
+                "commander": "^2.19.0",
+                "moo": "^0.5.0",
+                "railroad-diagrams": "^1.0.0",
+                "randexp": "0.4.6"
+            }
+        },
+        "parseley": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.7.0.tgz",
+            "integrity": "sha512-xyOytsdDu077M3/46Am+2cGXEKM9U9QclBDv7fimY7e+BBlxh2JcBp2mgNsmkyA9uvgyTjVzDi7cP1v4hcFxbw==",
+            "requires": {
+                "moo": "^0.5.1",
+                "nearley": "^2.20.1"
+            }
+        },
+        "railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A=="
+        },
+        "randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "requires": {
+                "discontinuous-range": "1.0.0",
+                "ret": "~0.1.10"
+            }
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "selderee": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.6.0.tgz",
+            "integrity": "sha512-ibqWGV5aChDvfVdqNYuaJP/HnVBhlRGSRrlbttmlMpHcLuTqqbMH36QkSs9GEgj5M88JDYLI8eyP94JaQ8xRlg==",
+            "requires": {
+                "parseley": "^0.7.0"
             }
         }
     }

--- a/services/keyphrase/functions/scrape-url/package.json
+++ b/services/keyphrase/functions/scrape-url/package.json
@@ -3,6 +3,9 @@
     "version": "1.0.0",
     "dependencies": {
         "@ashley-evans/buzzword-crawl-client": "1.0.0",
-        "htmlparser2": "8.0.1"
+        "html-to-text": "8.2.1"
+    },
+    "devDependencies": {
+        "@types/html-to-text": "^8.1.1"
     }
 }


### PR DESCRIPTION
Resolves #458 

# What

Replaced use of htmlparser2 with html-to-text
- Configured to ignore hrefs and src attributes

# Why

html-to-text comes with a number of in-built formatters/selectors that handle text parsing without hand crafting a solution with htmlparser2
- Block formatter in built that separates `p` elements with 2 newlines, fixing the issues with htmlparser2 implementation