### PR TITLE
Feature/328 find keyphrases esm support

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -123,7 +123,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Run Unit Tests
               run: |
-                  ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --group=-integration
+                  node --experimental-vm-modules ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --group=-integration
     integration-test:
         runs-on: ubuntu-latest
         needs: changed

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
         "<rootDir>/packages/crawl-client",
         "<rootDir>/services/crawl",
         "<rootDir>/services/keyphrase",
+        "<rootDir>/services/keyphrase/functions/find-keyphrases",
         "<rootDir>/ui",
     ],
 };

--- a/services/crawl/tsconfig.build.json
+++ b/services/crawl/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": ""
-    },
     "exclude": ["**/__tests__/**/*", "jest.config.js"]
 }

--- a/services/keyphrase/functions/find-keyphrases/__tests__/find-keyphrases.test.ts
+++ b/services/keyphrase/functions/find-keyphrases/__tests__/find-keyphrases.test.ts
@@ -1,3 +1,5 @@
+import { jest } from "@jest/globals";
+
 jest.mock("buzzword-keyphrase-text-repository-library");
 
 beforeEach(() => {
@@ -9,6 +11,6 @@ test("throws error if parsed content S3 bucket name is undefined", async () => {
 
     expect.assertions(1);
     await expect(async () => {
-        await import("../find-keyphrases");
+        await import("../find-keyphrases.js");
     }).rejects.toThrow(new Error("Parsed Content S3 bucket has not been set."));
 });

--- a/services/keyphrase/functions/find-keyphrases/adapters/KeyphraseEventAdapter.ts
+++ b/services/keyphrase/functions/find-keyphrases/adapters/KeyphraseEventAdapter.ts
@@ -1,11 +1,11 @@
 import { JSONSchemaType } from "ajv";
 import { AjvValidator } from "@ashley-evans/buzzword-object-validator";
 
-import KeyphrasesPort from "../ports/KeyphrasePort";
+import KeyphrasesPort from "../ports/KeyphrasePort.js";
 import {
     KeyphrasesEvent,
     KeyphrasePrimaryAdapter,
-} from "../ports/KeyphrasePrimaryAdapter";
+} from "../ports/KeyphrasePrimaryAdapter.js";
 
 const schema: JSONSchemaType<KeyphrasesEvent> = {
     type: "object",

--- a/services/keyphrase/functions/find-keyphrases/adapters/__tests__/KeyphraseEventAdapter.test.ts
+++ b/services/keyphrase/functions/find-keyphrases/adapters/__tests__/KeyphraseEventAdapter.test.ts
@@ -1,8 +1,8 @@
 import { mock } from "jest-mock-extended";
 
-import KeyphrasesPort from "../../ports/KeyphrasePort";
-import { KeyphrasesEvent } from "../../ports/KeyphrasePrimaryAdapter";
-import KeyphraseSQSAdapter from "../KeyphraseEventAdapter";
+import KeyphrasesPort from "../../ports/KeyphrasePort.js";
+import { KeyphrasesEvent } from "../../ports/KeyphrasePrimaryAdapter.js";
+import KeyphraseSQSAdapter from "../KeyphraseEventAdapter.js";
 
 const mockKeyphrasesPort = mock<KeyphrasesPort>();
 

--- a/services/keyphrase/functions/find-keyphrases/domain/KeyphraseFinder.ts
+++ b/services/keyphrase/functions/find-keyphrases/domain/KeyphraseFinder.ts
@@ -1,4 +1,8 @@
 import { TextRepository } from "buzzword-keyphrase-text-repository-library";
+import { retext } from "retext";
+import retextPos from "retext-pos";
+import retextKeywords from "retext-keywords";
+import { toString } from "nlcst-to-string";
 
 import KeyphrasesPort from "../ports/KeyphrasePort.js";
 
@@ -9,11 +13,6 @@ class KeyphraseFinder implements KeyphrasesPort {
         const uniqueKeyphrases = new Set<string>();
         const content = await this.parsedContentRepository.getPageText(url);
         if (content) {
-            const { retext } = await import("retext");
-            const retextPos = (await import("retext-pos")).default;
-            const retextKeywords = (await import("retext-keywords")).default;
-            const { toString } = await import("nlcst-to-string");
-
             console.log(`Starting keyphrase analysis for: ${url.toString()}`);
             const parsedFile = await retext()
                 .use(retextPos)

--- a/services/keyphrase/functions/find-keyphrases/domain/KeyphraseFinder.ts
+++ b/services/keyphrase/functions/find-keyphrases/domain/KeyphraseFinder.ts
@@ -1,15 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
-// @ts-ignore
-import retext from "retext";
-// @ts-ignore
-import retextPos from "retext-pos";
-// @ts-ignore
-import retextKeywords from "retext-keywords";
-// @ts-ignore
-import toString from "nlcst-to-string";
 import { TextRepository } from "buzzword-keyphrase-text-repository-library";
 
-import KeyphrasesPort from "../ports/KeyphrasePort";
+import KeyphrasesPort from "../ports/KeyphrasePort.js";
 
 class KeyphraseFinder implements KeyphrasesPort {
     constructor(private parsedContentRepository: TextRepository) {}
@@ -18,24 +9,35 @@ class KeyphraseFinder implements KeyphrasesPort {
         const uniqueKeyphrases = new Set<string>();
         const content = await this.parsedContentRepository.getPageText(url);
         if (content) {
+            const { retext } = await import("retext");
+            const retextPos = (await import("retext-pos")).default;
+            const retextKeywords = (await import("retext-keywords")).default;
+            const { toString } = await import("nlcst-to-string");
+
             console.log(`Starting keyphrase analysis for: ${url.toString()}`);
             const parsedFile = await retext()
                 .use(retextPos)
                 .use(retextKeywords)
                 .process(content);
-
             console.log(`Completed keyphrase analysis for: ${url.toString()}`);
-            for (const keyword of parsedFile.data.keywords) {
-                const current = toString(keyword.matches[0].node).toLowerCase();
-                uniqueKeyphrases.add(current);
+
+            if (parsedFile.data.keywords) {
+                for (const keyword of parsedFile.data.keywords) {
+                    const current = toString(
+                        keyword.matches[0].node
+                    ).toLowerCase();
+                    uniqueKeyphrases.add(current);
+                }
             }
 
-            for (const keyphrase of parsedFile.data.keyphrases) {
-                const current = keyphrase.matches[0].nodes
-                    .map((node: unknown) => toString(node))
-                    .join("")
-                    .toLowerCase();
-                uniqueKeyphrases.add(current);
+            if (parsedFile.data.keyphrases) {
+                for (const keyphrase of parsedFile.data.keyphrases) {
+                    const current = keyphrase.matches[0].nodes
+                        .map((node) => toString(node))
+                        .join("")
+                        .toLowerCase();
+                    uniqueKeyphrases.add(current);
+                }
             }
         }
 

--- a/services/keyphrase/functions/find-keyphrases/domain/__tests__/KeyphraseFinder.test.ts
+++ b/services/keyphrase/functions/find-keyphrases/domain/__tests__/KeyphraseFinder.test.ts
@@ -1,7 +1,8 @@
 import { mock } from "jest-mock-extended";
 import { TextRepository } from "buzzword-keyphrase-text-repository-library";
+import { jest } from "@jest/globals";
 
-import KeyphraseFinder from "../KeyphraseFinder";
+import KeyphraseFinder from "../KeyphraseFinder.js";
 
 const VALID_URL = new URL("https://www.example.com/");
 const TERM_CONTENT =

--- a/services/keyphrase/functions/find-keyphrases/find-keyphrases.ts
+++ b/services/keyphrase/functions/find-keyphrases/find-keyphrases.ts
@@ -3,9 +3,9 @@ import {
     TextS3Repository,
 } from "buzzword-keyphrase-text-repository-library";
 
-import EventAdapter from "./adapters/KeyphraseEventAdapter";
-import KeyphraseFinder from "./domain/KeyphraseFinder";
-import { KeyphrasesEvent } from "./ports/KeyphrasePrimaryAdapter";
+import EventAdapter from "./adapters/KeyphraseEventAdapter.js";
+import KeyphraseFinder from "./domain/KeyphraseFinder.js";
+import { KeyphrasesEvent } from "./ports/KeyphrasePrimaryAdapter.js";
 
 function createParsedContentRepository(): TextRepository {
     if (!process.env.PARSED_CONTENT_S3_BUCKET_NAME) {

--- a/services/keyphrase/functions/find-keyphrases/jest.config.cjs
+++ b/services/keyphrase/functions/find-keyphrases/jest.config.cjs
@@ -1,0 +1,18 @@
+const config = require("../../jest.config.js");
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+    ...config,
+    globals: {
+        "ts-jest": {
+            compiler: "ttypescript",
+            useESM: true,
+        },
+    },
+    setupFiles: ["<rootDir>/../../config/ts-auto-mock-config.ts"],
+    transform: {},
+    extensionsToTreatAsEsm: [".ts"],
+    moduleNameMapper: {
+        "^(\\.{1,2}/.*)\\.js$": "$1",
+    },
+};

--- a/services/keyphrase/functions/find-keyphrases/package-lock.json
+++ b/services/keyphrase/functions/find-keyphrases/package-lock.json
@@ -8,10 +8,18 @@
             "name": "buzzword-keyphrase-find-keyphrases-lambda",
             "version": "1.0.0",
             "dependencies": {
-                "nlcst-to-string": "2.0.4",
-                "retext": "7.0.1",
-                "retext-keywords": "6.0.0",
-                "retext-pos": "3.0.0"
+                "nlcst-to-string": "3.1.0",
+                "retext": "8.1.0",
+                "retext-keywords": "7.2.0",
+                "retext-pos": "4.1.0"
+            }
+        },
+        "node_modules/@types/nlcst": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-1.0.0.tgz",
+            "integrity": "sha512-3TGCfOcy8R8mMQ4CNSNOe3PG66HttvjcLzCoOpvXvDtfWOTi+uT/rxeOKm/qEwbM4SNe1O/PjdiBK2YcTjU4OQ==",
+            "dependencies": {
+                "@types/unist": "*"
             }
         },
         "node_modules/@types/unist": {
@@ -20,18 +28,18 @@
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
         },
         "node_modules/array-iterate": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.4.tgz",
-            "integrity": "sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+            "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/bail": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -41,11 +49,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/is-buffer": {
             "version": "2.0.5",
@@ -70,30 +73,36 @@
             }
         },
         "node_modules/is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
             "engines": {
-                "node": ">=8"
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/nlcst-to-string": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.4.tgz",
-            "integrity": "sha512-3x3jwTd6UPG7vi5k4GEzvxJ5rDA7hVUIRNHPblKuMVP9Z3xmlsd9cgLcpAMkc5uPOBna82EeshROFhsPkbnTZg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.0.tgz",
+            "integrity": "sha512-Y8HQWKw/zrHTCnu2zcFBN1dV6vN0NUG7s5fkEj380G8tF3R+vA2KG+tDl2QoHVQCTHGHVXwoni2RQkDSFQb1PA==",
+            "dependencies": {
+                "@types/nlcst": "^1.0.0"
+            },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/parse-latin": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.3.0.tgz",
-            "integrity": "sha512-TYKL+K98dcAWoCw/Ac1yrPviU8Trk+/gmjQVaoWEFDZmVD4KRg6c/80xKqNNFQObo2mTONgF8trzAf2UTwKafw==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-5.0.1.tgz",
+            "integrity": "sha512-b/K8ExXaWC9t34kKeDV8kGXBkXZ1HCSAZRYE7HR14eA1GlXX5L8iWhs8USJNhQU9q5ci413jCKF0gOyovvyRBg==",
             "dependencies": {
-                "nlcst-to-string": "^2.0.0",
-                "unist-util-modify-children": "^2.0.0",
-                "unist-util-visit-children": "^1.0.0"
+                "nlcst-to-string": "^3.0.0",
+                "unist-util-modify-children": "^3.0.0",
+                "unist-util-visit-children": "^2.0.0"
             },
             "funding": {
                 "type": "github",
@@ -109,13 +118,14 @@
             }
         },
         "node_modules/retext": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/retext/-/retext-7.0.1.tgz",
-            "integrity": "sha512-N0IaEDkvUjqyfn3/gwxVfI51IxfGzOiVXqPLWnKeCDbiQdxSg0zebzHPxXWnL7TeplAJ+RE4uqrXyYN//s9HjQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/retext/-/retext-8.1.0.tgz",
+            "integrity": "sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==",
             "dependencies": {
-                "retext-latin": "^2.0.0",
-                "retext-stringify": "^2.0.0",
-                "unified": "^8.0.0"
+                "@types/nlcst": "^1.0.0",
+                "retext-latin": "^3.0.0",
+                "retext-stringify": "^3.0.0",
+                "unified": "^10.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -123,13 +133,15 @@
             }
         },
         "node_modules/retext-keywords": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/retext-keywords/-/retext-keywords-6.0.0.tgz",
-            "integrity": "sha512-jDdindZTevx7uvDPcLG86qsfr6++szKXgGtQ5PjkkCxpEPpnyBeGovlTR7BCfyRatEoLX66iiTmpsY/hhAjbzA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/retext-keywords/-/retext-keywords-7.2.0.tgz",
+            "integrity": "sha512-bYIMeuhUO324maKE5t+3DaRVjZc3GD9K3pi4adRWbgBjyHQCDbxQmTebBkpXwVSUkN49IIL5qgeZkm3X0eeUVg==",
             "dependencies": {
-                "nlcst-to-string": "^2.0.0",
-                "stemmer": "^1.0.0",
-                "unist-util-visit": "^2.0.0"
+                "@types/nlcst": "^1.0.0",
+                "nlcst-to-string": "^3.0.0",
+                "stemmer": "^2.0.0",
+                "unified": "^10.0.0",
+                "unist-util-visit": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -137,12 +149,14 @@
             }
         },
         "node_modules/retext-latin": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-2.0.4.tgz",
-            "integrity": "sha512-fOoSSoQgDZ+l/uS81oxI3alBghDUPja0JEl0TpQxI6MN+dhM6fLFumPJwMZ4PJTyL5FFAgjlsdv8IX+6IRuwMw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-3.1.0.tgz",
+            "integrity": "sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==",
             "dependencies": {
-                "parse-latin": "^4.0.0",
-                "unherit": "^1.0.4"
+                "@types/nlcst": "^1.0.0",
+                "parse-latin": "^5.0.0",
+                "unherit": "^3.0.0",
+                "unified": "^10.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -150,13 +164,15 @@
             }
         },
         "node_modules/retext-pos": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/retext-pos/-/retext-pos-3.0.0.tgz",
-            "integrity": "sha512-OQ6WtYodx7ONuPBbX3cOC8+U9DzJEF365NbBy0LSuf28b3Nf6AK+lSnF7S23zhYrpbh1DVU0rdMTRh0ggYXnEg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/retext-pos/-/retext-pos-4.1.0.tgz",
+            "integrity": "sha512-iTEXWVq2GbZrv7BocOjZiIZTaWqVBQVRj+Lr9TcRJwFAftDdy5vJM/4OQMwZNONWuWKAI0qQsLJEJSOyPIwl1Q==",
             "dependencies": {
-                "nlcst-to-string": "^2.0.0",
+                "@types/nlcst": "^1.0.0",
+                "nlcst-to-string": "^3.0.0",
                 "pos": "^0.4.2",
-                "unist-util-visit": "^2.0.0"
+                "unified": "^10.0.0",
+                "unist-util-visit": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -164,11 +180,13 @@
             }
         },
         "node_modules/retext-stringify": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-2.0.4.tgz",
-            "integrity": "sha512-xOtx5mFJBoT3j7PBtiY2I+mEGERNniofWktI1cKXvjMEJPOuqve0dghLHO1+gz/gScLn4zqspDGv4kk2wS5kSA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-3.1.0.tgz",
+            "integrity": "sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==",
             "dependencies": {
-                "nlcst-to-string": "^2.0.0"
+                "@types/nlcst": "^1.0.0",
+                "nlcst-to-string": "^3.0.0",
+                "unified": "^10.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -176,9 +194,9 @@
             }
         },
         "node_modules/stemmer": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-1.0.5.tgz",
-            "integrity": "sha512-SLq7annzSKRDStasOJJoftCSCzBCKmBmH38jC4fDtCunAqOzpTpIm9zmaHmwNJiZ8gLe9qpVdBVbEG2DC5dE2A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-2.0.1.tgz",
+            "integrity": "sha512-bkWvSX2JR4nSZFfs113kd4C6X13bBBrg4fBKv2pVdzpdQI2LA5pZcWzTFNdkYsiUNl13E4EzymSRjZ0D55jBYg==",
             "bin": {
                 "stemmer": "cli.js"
             },
@@ -188,37 +206,35 @@
             }
         },
         "node_modules/trough": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+            "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/unherit": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-            "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-            "dependencies": {
-                "inherits": "^2.0.0",
-                "xtend": "^4.0.0"
-            },
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.1.tgz",
+            "integrity": "sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/unified": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-            "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
             "dependencies": {
-                "bail": "^1.0.0",
+                "@types/unist": "^2.0.0",
+                "bail": "^2.0.0",
                 "extend": "^3.0.0",
-                "is-plain-obj": "^2.0.0",
-                "trough": "^1.0.0",
-                "vfile": "^4.0.0"
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -226,20 +242,21 @@
             }
         },
         "node_modules/unist-util-is": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+            "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/unist-util-modify-children": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-2.0.0.tgz",
-            "integrity": "sha512-HGrj7JQo9DwZt8XFsX8UD4gGqOsIlCih9opG6Y+N11XqkBGKzHo8cvDi+MfQQgiZ7zXRUiQREYHhjOBHERTMdg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-3.1.0.tgz",
+            "integrity": "sha512-L0UizdncPZ1NIwpmkwFdLo2NaK2Eb5LU/vaQ7lZGkAaOBZfsHp+8T/gVWPVmmMO1hj6gc+XeMoytut8jr7fdyA==",
             "dependencies": {
-                "array-iterate": "^1.0.0"
+                "@types/unist": "^2.0.0",
+                "array-iterate": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -247,11 +264,11 @@
             }
         },
         "node_modules/unist-util-stringify-position": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-            "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+            "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
             "dependencies": {
-                "@types/unist": "^2.0.2"
+                "@types/unist": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -259,13 +276,13 @@
             }
         },
         "node_modules/unist-util-visit": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
+            "integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
             "dependencies": {
                 "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0",
-                "unist-util-visit-parents": "^3.0.0"
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.1.1"
             },
             "funding": {
                 "type": "opencollective",
@@ -273,21 +290,24 @@
             }
         },
         "node_modules/unist-util-visit-children": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz",
-            "integrity": "sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-2.0.1.tgz",
+            "integrity": "sha512-2cEU3dhV1hMfO9ajwb8rJsDedMfsahsm6fCfR8LxDR/w7KcB5lzHQ9dBTQIXsWGNWBFH5MPmaFP3Xh0dWLqClQ==",
+            "dependencies": {
+                "@types/unist": "^2.0.0"
+            },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/unist-util-visit-parents": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz",
+            "integrity": "sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==",
             "dependencies": {
                 "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0"
+                "unist-util-is": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -295,14 +315,14 @@
             }
         },
         "node_modules/vfile": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-            "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
+            "integrity": "sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==",
             "dependencies": {
                 "@types/unist": "^2.0.0",
                 "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0",
-                "vfile-message": "^2.0.0"
+                "unist-util-stringify-position": "^3.0.0",
+                "vfile-message": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -310,52 +330,47 @@
             }
         },
         "node_modules/vfile-message": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-            "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.3.tgz",
+            "integrity": "sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==",
             "dependencies": {
                 "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0"
+                "unist-util-stringify-position": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "engines": {
-                "node": ">=0.4"
-            }
         }
     },
     "dependencies": {
+        "@types/nlcst": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-1.0.0.tgz",
+            "integrity": "sha512-3TGCfOcy8R8mMQ4CNSNOe3PG66HttvjcLzCoOpvXvDtfWOTi+uT/rxeOKm/qEwbM4SNe1O/PjdiBK2YcTjU4OQ==",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
         "@types/unist": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
             "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
         },
         "array-iterate": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-1.1.4.tgz",
-            "integrity": "sha512-sNRaPGh9nnmdC8Zf+pT3UqP8rnWj5Hf9wiFGsX3wUQ2yVSIhO2ShFwCoceIPpB41QF6i2OEmrHmCo36xronCVA=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+            "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg=="
         },
         "bail": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
         },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is-buffer": {
             "version": "2.0.5",
@@ -363,23 +378,26 @@
             "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
         },
         "is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
         },
         "nlcst-to-string": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-2.0.4.tgz",
-            "integrity": "sha512-3x3jwTd6UPG7vi5k4GEzvxJ5rDA7hVUIRNHPblKuMVP9Z3xmlsd9cgLcpAMkc5uPOBna82EeshROFhsPkbnTZg=="
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.0.tgz",
+            "integrity": "sha512-Y8HQWKw/zrHTCnu2zcFBN1dV6vN0NUG7s5fkEj380G8tF3R+vA2KG+tDl2QoHVQCTHGHVXwoni2RQkDSFQb1PA==",
+            "requires": {
+                "@types/nlcst": "^1.0.0"
+            }
         },
         "parse-latin": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-4.3.0.tgz",
-            "integrity": "sha512-TYKL+K98dcAWoCw/Ac1yrPviU8Trk+/gmjQVaoWEFDZmVD4KRg6c/80xKqNNFQObo2mTONgF8trzAf2UTwKafw==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-5.0.1.tgz",
+            "integrity": "sha512-b/K8ExXaWC9t34kKeDV8kGXBkXZ1HCSAZRYE7HR14eA1GlXX5L8iWhs8USJNhQU9q5ci413jCKF0gOyovvyRBg==",
             "requires": {
-                "nlcst-to-string": "^2.0.0",
-                "unist-util-modify-children": "^2.0.0",
-                "unist-util-visit-children": "^1.0.0"
+                "nlcst-to-string": "^3.0.0",
+                "unist-util-modify-children": "^3.0.0",
+                "unist-util-visit-children": "^2.0.0"
             }
         },
         "pos": {
@@ -388,152 +406,158 @@
             "integrity": "sha1-IOnHf77tzDVoI86mPHWFys6Tvio="
         },
         "retext": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/retext/-/retext-7.0.1.tgz",
-            "integrity": "sha512-N0IaEDkvUjqyfn3/gwxVfI51IxfGzOiVXqPLWnKeCDbiQdxSg0zebzHPxXWnL7TeplAJ+RE4uqrXyYN//s9HjQ==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/retext/-/retext-8.1.0.tgz",
+            "integrity": "sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==",
             "requires": {
-                "retext-latin": "^2.0.0",
-                "retext-stringify": "^2.0.0",
-                "unified": "^8.0.0"
+                "@types/nlcst": "^1.0.0",
+                "retext-latin": "^3.0.0",
+                "retext-stringify": "^3.0.0",
+                "unified": "^10.0.0"
             }
         },
         "retext-keywords": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/retext-keywords/-/retext-keywords-6.0.0.tgz",
-            "integrity": "sha512-jDdindZTevx7uvDPcLG86qsfr6++szKXgGtQ5PjkkCxpEPpnyBeGovlTR7BCfyRatEoLX66iiTmpsY/hhAjbzA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/retext-keywords/-/retext-keywords-7.2.0.tgz",
+            "integrity": "sha512-bYIMeuhUO324maKE5t+3DaRVjZc3GD9K3pi4adRWbgBjyHQCDbxQmTebBkpXwVSUkN49IIL5qgeZkm3X0eeUVg==",
             "requires": {
-                "nlcst-to-string": "^2.0.0",
-                "stemmer": "^1.0.0",
-                "unist-util-visit": "^2.0.0"
+                "@types/nlcst": "^1.0.0",
+                "nlcst-to-string": "^3.0.0",
+                "stemmer": "^2.0.0",
+                "unified": "^10.0.0",
+                "unist-util-visit": "^4.0.0"
             }
         },
         "retext-latin": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-2.0.4.tgz",
-            "integrity": "sha512-fOoSSoQgDZ+l/uS81oxI3alBghDUPja0JEl0TpQxI6MN+dhM6fLFumPJwMZ4PJTyL5FFAgjlsdv8IX+6IRuwMw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-3.1.0.tgz",
+            "integrity": "sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==",
             "requires": {
-                "parse-latin": "^4.0.0",
-                "unherit": "^1.0.4"
+                "@types/nlcst": "^1.0.0",
+                "parse-latin": "^5.0.0",
+                "unherit": "^3.0.0",
+                "unified": "^10.0.0"
             }
         },
         "retext-pos": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/retext-pos/-/retext-pos-3.0.0.tgz",
-            "integrity": "sha512-OQ6WtYodx7ONuPBbX3cOC8+U9DzJEF365NbBy0LSuf28b3Nf6AK+lSnF7S23zhYrpbh1DVU0rdMTRh0ggYXnEg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/retext-pos/-/retext-pos-4.1.0.tgz",
+            "integrity": "sha512-iTEXWVq2GbZrv7BocOjZiIZTaWqVBQVRj+Lr9TcRJwFAftDdy5vJM/4OQMwZNONWuWKAI0qQsLJEJSOyPIwl1Q==",
             "requires": {
-                "nlcst-to-string": "^2.0.0",
+                "@types/nlcst": "^1.0.0",
+                "nlcst-to-string": "^3.0.0",
                 "pos": "^0.4.2",
-                "unist-util-visit": "^2.0.0"
+                "unified": "^10.0.0",
+                "unist-util-visit": "^4.0.0"
             }
         },
         "retext-stringify": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-2.0.4.tgz",
-            "integrity": "sha512-xOtx5mFJBoT3j7PBtiY2I+mEGERNniofWktI1cKXvjMEJPOuqve0dghLHO1+gz/gScLn4zqspDGv4kk2wS5kSA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-3.1.0.tgz",
+            "integrity": "sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==",
             "requires": {
-                "nlcst-to-string": "^2.0.0"
+                "@types/nlcst": "^1.0.0",
+                "nlcst-to-string": "^3.0.0",
+                "unified": "^10.0.0"
             }
         },
         "stemmer": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-1.0.5.tgz",
-            "integrity": "sha512-SLq7annzSKRDStasOJJoftCSCzBCKmBmH38jC4fDtCunAqOzpTpIm9zmaHmwNJiZ8gLe9qpVdBVbEG2DC5dE2A=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-2.0.1.tgz",
+            "integrity": "sha512-bkWvSX2JR4nSZFfs113kd4C6X13bBBrg4fBKv2pVdzpdQI2LA5pZcWzTFNdkYsiUNl13E4EzymSRjZ0D55jBYg=="
         },
         "trough": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+            "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
         },
         "unherit": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-            "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-            "requires": {
-                "inherits": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.1.tgz",
+            "integrity": "sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg=="
         },
         "unified": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.2.tgz",
-            "integrity": "sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
             "requires": {
-                "bail": "^1.0.0",
+                "@types/unist": "^2.0.0",
+                "bail": "^2.0.0",
                 "extend": "^3.0.0",
-                "is-plain-obj": "^2.0.0",
-                "trough": "^1.0.0",
-                "vfile": "^4.0.0"
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^5.0.0"
             }
         },
         "unist-util-is": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+            "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
         },
         "unist-util-modify-children": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-2.0.0.tgz",
-            "integrity": "sha512-HGrj7JQo9DwZt8XFsX8UD4gGqOsIlCih9opG6Y+N11XqkBGKzHo8cvDi+MfQQgiZ7zXRUiQREYHhjOBHERTMdg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-3.1.0.tgz",
+            "integrity": "sha512-L0UizdncPZ1NIwpmkwFdLo2NaK2Eb5LU/vaQ7lZGkAaOBZfsHp+8T/gVWPVmmMO1hj6gc+XeMoytut8jr7fdyA==",
             "requires": {
-                "array-iterate": "^1.0.0"
+                "@types/unist": "^2.0.0",
+                "array-iterate": "^2.0.0"
             }
         },
         "unist-util-stringify-position": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-            "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+            "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
             "requires": {
-                "@types/unist": "^2.0.2"
+                "@types/unist": "^2.0.0"
             }
         },
         "unist-util-visit": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
+            "integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
             "requires": {
                 "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0",
-                "unist-util-visit-parents": "^3.0.0"
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.1.1"
             }
         },
         "unist-util-visit-children": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-1.1.4.tgz",
-            "integrity": "sha512-sA/nXwYRCQVRwZU2/tQWUqJ9JSFM1X3x7JIOsIgSzrFHcfVt6NkzDtKzyxg2cZWkCwGF9CO8x4QNZRJRMK8FeQ=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-2.0.1.tgz",
+            "integrity": "sha512-2cEU3dhV1hMfO9ajwb8rJsDedMfsahsm6fCfR8LxDR/w7KcB5lzHQ9dBTQIXsWGNWBFH5MPmaFP3Xh0dWLqClQ==",
+            "requires": {
+                "@types/unist": "^2.0.0"
+            }
         },
         "unist-util-visit-parents": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz",
+            "integrity": "sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==",
             "requires": {
                 "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0"
+                "unist-util-is": "^5.0.0"
             }
         },
         "vfile": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-            "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
+            "integrity": "sha512-ADBsmerdGBs2WYckrLBEmuETSPyTD4TuLxTrw0DvjirxW1ra4ZwkbzG8ndsv3Q57smvHxo677MHaQrY9yxH8cA==",
             "requires": {
                 "@types/unist": "^2.0.0",
                 "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0",
-                "vfile-message": "^2.0.0"
+                "unist-util-stringify-position": "^3.0.0",
+                "vfile-message": "^3.0.0"
             }
         },
         "vfile-message": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-            "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.3.tgz",
+            "integrity": "sha512-0yaU+rj2gKAyEk12ffdSbBfjnnj+b1zqTBv3OQCTn8yEB02bsPizwdBPrLJjHnK+cU9EMMcUnNv938XcZIkmdA==",
             "requires": {
                 "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0"
+                "unist-util-stringify-position": "^3.0.0"
             }
-        },
-        "xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
     }
 }

--- a/services/keyphrase/functions/find-keyphrases/package.json
+++ b/services/keyphrase/functions/find-keyphrases/package.json
@@ -1,10 +1,11 @@
 {
     "name": "buzzword-keyphrase-find-keyphrases-lambda",
     "version": "1.0.0",
+    "type": "module",
     "dependencies": {
-        "nlcst-to-string": "2.0.4",
-        "retext": "7.0.1",
-        "retext-keywords": "6.0.0",
-        "retext-pos": "3.0.0"
+        "nlcst-to-string": "3.1.0",
+        "retext": "8.1.0",
+        "retext-keywords": "7.2.0",
+        "retext-pos": "4.1.0"
     }
 }

--- a/services/keyphrase/jest.config.js
+++ b/services/keyphrase/jest.config.js
@@ -14,4 +14,8 @@ module.exports = {
         },
     },
     setupFiles: ["<rootDir>/config/ts-auto-mock-config.ts"],
+    testPathIgnorePatterns: [
+        "/node_modules/",
+        "<rootDir>/functions/find-keyphrases/",
+    ],
 };

--- a/services/keyphrase/tsconfig.build.json
+++ b/services/keyphrase/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
     "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "rootDir": ""
-    },
     "exclude": ["**/__tests__/**/*", "jest.config.js", "config/**/*"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,8 @@
 {
     "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "Node16",
+        "moduleResolution": "Node16",
         "outDir": "dist",
         "allowJs": true,
         "lib": ["DOM"]


### PR DESCRIPTION
Resolves #328 

# What

Updated find keyphrases lambda to use latest versions of retext libraries
- Required updates to treat find keyphrase lambda package as ESM to prevent TS from transpiling the imports into requires
- Also requires specific jest config to enable ts jest to work with ESM packages
Updated base tsconfig to use node16 module/moduleresolution
Updated service CI pipeline definition to use node experimental vm modules when running jest

# Why

Retext is now pure ESM meaning that it must by imported, not required meaning that the find keyphrase lambda needed to either dynamically import these dependencies or become a ESM. Updating the module and module resolution to node16 enables tsc to determine whether a package is ESM or CommonJS via the type in the package.json
- This enabled upgrading the Retext and nlcst-to-string dependencies to latest

Jest requires experimental VM modules to support running tests against ESM
