### PR TITLE
chore: align ci npm scripts

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -123,7 +123,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Run Unit Tests
               run: |
-                  node --experimental-vm-modules ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --group=-integration
+                  npm run test:unit -- --testPathPattern=${{ inputs.path }}
     integration-test:
         runs-on: ubuntu-latest
         needs: changed
@@ -148,7 +148,7 @@ jobs:
                   cors: "*"
             - name: Run Integration Tests
               run: |
-                  ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --group=integration
+                  npm run test:integration -- --testPathPattern=${{ inputs.path }}
     deploy:
         runs-on: ubuntu-latest
         needs:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "ci": "npx lerna bootstrap --ci --ignore=how-many-buzzwords-ui && npm --prefix ./ui/ run ci",
         "clean": "rm -rf `find . -type d -name node_modules`",
         "test": "npm run test:unit && npm run test:integration",
-        "test:unit": "node node_modules/.bin/jest --verbose --group=-integration",
+        "test:unit": "node --experimental-vm-modules node_modules/.bin/jest --verbose --group=-integration",
         "test:integration": "node node_modules/.bin/jest --verbose --group=integration",
         "prepare": "husky install"
     }


### PR DESCRIPTION
# What

Updated npm unit test script to use experimental vm module flag to enable jest to support ESM
Updated service.yml to refer to npm scripts

# Why

npm script: Previously broken as now using the experimental vm module flag is mandatory when testing services
service.yml: To ensure consistency and reduce overhead when changing common scripts