### PR TITLE
Feature/454 prevent re aggregate

### DIFF
--- a/services/keyphrase/functions/total-occurrences/adapters/__tests__/TotalOccurrencesStreamAdapter.test.ts
+++ b/services/keyphrase/functions/total-occurrences/adapters/__tests__/TotalOccurrencesStreamAdapter.test.ts
@@ -115,7 +115,7 @@ function createRecord(
                     },
                 }),
             },
-            ...((newOccurrences || newAggregated) && {
+            ...((newOccurrences || newAggregated != undefined) && {
                 NewImage: {
                     ...(newOccurrences && {
                         [KeyphraseTableNonKeyFields.Occurrences]: {
@@ -129,7 +129,7 @@ function createRecord(
                     }),
                 },
             }),
-            ...((oldOccurrences || oldAggregated) && {
+            ...((oldOccurrences || oldAggregated != undefined) && {
                 OldImage: {
                     ...(oldOccurrences && {
                         [KeyphraseTableNonKeyFields.Occurrences]: {

--- a/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/TotalOccurrencesDomain.ts
@@ -17,7 +17,7 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
         const totals = this.createTotalUpdates(items);
         const occurrenceUpdates = this.addOccurrences(totals.additions);
         const aggregateFlagUpdates = this.updateAggregateFlags(
-            totals.aggregated
+            totals.unchanged
         );
 
         return (
@@ -55,13 +55,17 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
 
     private createTotalUpdates(items: (OccurrenceItem | TotalItem)[]): {
         additions: SiteKeyphraseOccurrences[];
-        aggregated: SiteKeyphrase[];
+        unchanged: SiteKeyphrase[];
     } {
         const newAdditions: SiteKeyphraseOccurrences[] = [];
-        const alreadyAggregated: SiteKeyphrase[] = [];
+        const unchanged: SiteKeyphrase[] = [];
 
         for (const item of items) {
             if (this.isOccurrenceItem(item)) {
+                if (item.current.aggregated) {
+                    continue;
+                }
+
                 const newOccurrences = item.previous
                     ? item.current.occurrences - item.previous.occurrences
                     : item.current.occurrences;
@@ -74,7 +78,7 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
                         occurrences: newOccurrences,
                     });
                 } else {
-                    alreadyAggregated.push({
+                    unchanged.push({
                         baseURL: item.current.baseURL,
                         pathname: item.current.pathname,
                         keyphrase: item.current.keyphrase,
@@ -85,7 +89,7 @@ class TotalOccurrencesDomain implements TotalOccurrencesPort {
 
         return {
             additions: newAdditions,
-            aggregated: alreadyAggregated,
+            unchanged: unchanged,
         };
     }
 

--- a/services/keyphrase/functions/total-occurrences/domain/__tests__/TotalOccurrencesDomain.test.ts
+++ b/services/keyphrase/functions/total-occurrences/domain/__tests__/TotalOccurrencesDomain.test.ts
@@ -19,13 +19,15 @@ const domain = new TotalOccurrencesDomain(mockRepository);
 function createOccurrenceImage(
     url: URL,
     keyphrase: string,
-    occurrences: number
+    occurrences: number,
+    aggregated?: boolean
 ): SiteKeyphraseOccurrences {
     return {
         baseURL: url.hostname,
         pathname: url.pathname,
         keyphrase,
         occurrences,
+        aggregated,
     };
 }
 
@@ -323,3 +325,32 @@ test("returns failure if updating aggregated flag does not succeed", async () =>
 
     expect(actual).toBe(false);
 });
+
+test.each([
+    [
+        "a single occurrence item",
+        [
+            {
+                current: createOccurrenceImage(VALID_URL, "test", 5, true),
+            },
+        ],
+    ],
+    [
+        "multiple occurrence items",
+        [
+            {
+                current: createOccurrenceImage(VALID_URL, "test", 5, true),
+            },
+            {
+                current: createOccurrenceImage(VALID_URL, "wibble", 7, true),
+            },
+        ],
+    ],
+])(
+    "ignores %s if already set to aggregated",
+    async (message: string, items: OccurrenceItem[]) => {
+        await domain.updateTotal(items);
+
+        expect(mockRepository.addOccurrencesToTotals).not.toHaveBeenCalled();
+    }
+);


### PR DESCRIPTION
Resolves #454 

# What

Updated total occurrence lambda to:
- map aggregated flag for occurrence items
- ignore any item whose current aggregate flag value is true

# Why

Currently, the DynamoDB transaction would fail if the item had already been aggregated so the outcome is unchanged, however, DynamoDB charges for transaction failures - Therefore, adding this mapping + ignore reduces cost as we remove unnecessary transactions that we know will fail
