### PR TITLE
Feature/375 total occurrences partial failure

### DIFF
--- a/services/crawl/crawl-template.yml
+++ b/services/crawl/crawl-template.yml
@@ -194,6 +194,8 @@ Resources:
                     Properties:
                         Stream: !GetAtt URLsTable.StreamArn
                         StartingPosition: LATEST
+                        FunctionResponseTypes:
+                            - ReportBatchItemFailures
             Architectures:
                 - arm64
             Environment:

--- a/services/keyphrase/functions/total-occurrences/adapters/TotalOccurrencesStreamAdapter.ts
+++ b/services/keyphrase/functions/total-occurrences/adapters/TotalOccurrencesStreamAdapter.ts
@@ -1,12 +1,13 @@
 import {
-    DynamoDBRecord,
     DynamoDBStreamEvent,
+    SQSBatchItemFailure,
     SQSBatchResponse,
 } from "aws-lambda";
 import {
     KeyphraseTableConstants,
     KeyphraseTableKeyFields,
     KeyphraseTableNonKeyFields,
+    SiteKeyphrase,
 } from "buzzword-keyphrase-keyphrase-repository-library";
 import { JSONSchemaType } from "ajv";
 import { AjvValidator } from "@ashley-evans/buzzword-object-validator";
@@ -141,9 +142,12 @@ class TotalOccurrencesStreamAdapter implements DynamoDBSteamAdapter {
         }
 
         const itemsToTotal: (OccurrenceItem | TotalItem)[] = [];
+        const validRecords: ValidOccurrenceRecord[] = [];
         for (const record of event.Records) {
             try {
-                itemsToTotal.push(this.parseRecord(record));
+                const validRecord = this.validator.validate(record);
+                validRecords.push(validRecord);
+                itemsToTotal.push(this.parseRecord(validRecord));
             } catch {
                 console.log(
                     `Skipping invalid record: ${JSON.stringify(record)}`
@@ -155,19 +159,24 @@ class TotalOccurrencesStreamAdapter implements DynamoDBSteamAdapter {
             try {
                 const failures = await this.port.updateTotal(itemsToTotal);
                 if (failures.length > 0) {
-                    this.throwFailureError(itemsToTotal);
+                    return this.createPartialFailureResponse(
+                        validRecords,
+                        failures
+                    );
                 }
-            } catch {
-                this.throwFailureError(itemsToTotal);
+            } catch (ex) {
+                console.error(`An error occurred while totalling: ${ex}`);
+                this.throwFullError(itemsToTotal);
             }
         }
 
         return this.createResponse();
     }
 
-    private parseRecord(record: DynamoDBRecord): OccurrenceItem | TotalItem {
-        const validatedRecord = this.validator.validate(record);
-        const streamRecord = validatedRecord.dynamodb;
+    private parseRecord(
+        validRecord: ValidOccurrenceRecord
+    ): OccurrenceItem | TotalItem {
+        const streamRecord = validRecord.dynamodb;
         const partitionKey =
             streamRecord.Keys[KeyphraseTableKeyFields.HashKey].S;
         const sortKey = streamRecord.Keys[KeyphraseTableKeyFields.RangeKey].S;
@@ -182,7 +191,7 @@ class TotalOccurrencesStreamAdapter implements DynamoDBSteamAdapter {
                 ?.BOOL;
 
         if (
-            validatedRecord.eventName == AcceptedEventNames.Modify &&
+            validRecord.eventName == AcceptedEventNames.Modify &&
             !streamRecord.OldImage
         ) {
             throw new Error(
@@ -290,12 +299,49 @@ class TotalOccurrencesStreamAdapter implements DynamoDBSteamAdapter {
         return { batchItemFailures: [] };
     }
 
-    private throwFailureError(items: (OccurrenceItem | TotalItem)[]) {
+    private throwFullError(items: (OccurrenceItem | TotalItem)[]) {
         throw new Error(
             `Failed to update totals for provided records: ${JSON.stringify(
                 items
             )}`
         );
+    }
+
+    private createPartialFailureResponse(
+        validRecords: ValidOccurrenceRecord[],
+        failures: SiteKeyphrase[]
+    ): SQSBatchResponse {
+        console.error(
+            `Failed to update totals for: ${JSON.stringify(failures)}`
+        );
+
+        const batchItemFailures: SQSBatchItemFailure[] = failures.map(
+            (failure) => {
+                const matchingRecord = validRecords.find((record) => {
+                    const keys = record.dynamodb.Keys;
+                    return (
+                        keys[KeyphraseTableKeyFields.HashKey].S ==
+                            failure.baseURL,
+                        keys[KeyphraseTableKeyFields.RangeKey].S ==
+                            `${failure.pathname}#${failure.keyphrase}`
+                    );
+                });
+
+                if (!matchingRecord) {
+                    throw new Error(
+                        `Unable to find matching record for: ${JSON.stringify(
+                            failure
+                        )}`
+                    );
+                }
+
+                return {
+                    itemIdentifier: matchingRecord.dynamodb.SequenceNumber,
+                };
+            }
+        );
+
+        return { batchItemFailures };
     }
 }
 

--- a/services/keyphrase/functions/total-occurrences/adapters/TotalOccurrencesStreamAdapter.ts
+++ b/services/keyphrase/functions/total-occurrences/adapters/TotalOccurrencesStreamAdapter.ts
@@ -149,8 +149,8 @@ class TotalOccurrencesStreamAdapter implements DynamoDBSteamAdapter {
 
         if (itemsToTotal.length != 0) {
             try {
-                const success = await this.port.updateTotal(itemsToTotal);
-                if (!success) {
+                const failures = await this.port.updateTotal(itemsToTotal);
+                if (failures.length > 0) {
                     this.throwFailureError(itemsToTotal);
                 }
             } catch {

--- a/services/keyphrase/functions/total-occurrences/adapters/TotalOccurrencesStreamAdapter.ts
+++ b/services/keyphrase/functions/total-occurrences/adapters/TotalOccurrencesStreamAdapter.ts
@@ -30,6 +30,7 @@ type ValidOccurrenceRecord = {
             [KeyphraseTableKeyFields.HashKey]: { S: string };
             [KeyphraseTableKeyFields.RangeKey]: { S: string };
         };
+        SequenceNumber: string;
         NewImage: {
             [KeyphraseTableNonKeyFields.Occurrences]: { N: string };
             [KeyphraseTableNonKeyFields.Aggregated]?: { BOOL: boolean };
@@ -73,6 +74,9 @@ const schema: JSONSchemaType<ValidOccurrenceRecord> = {
                         KeyphraseTableKeyFields.HashKey,
                         KeyphraseTableKeyFields.RangeKey,
                     ],
+                },
+                SequenceNumber: {
+                    type: "string",
                 },
                 NewImage: {
                     type: "object",
@@ -118,7 +122,7 @@ const schema: JSONSchemaType<ValidOccurrenceRecord> = {
                     nullable: true,
                 },
             },
-            required: ["Keys", "NewImage"],
+            required: ["Keys", "NewImage", "SequenceNumber"],
         },
     },
     required: ["eventName", "dynamodb"],

--- a/services/keyphrase/functions/total-occurrences/adapters/__tests__/TotalOccurrencesStreamAdapter.test.ts
+++ b/services/keyphrase/functions/total-occurrences/adapters/__tests__/TotalOccurrencesStreamAdapter.test.ts
@@ -236,7 +236,7 @@ beforeAll(() => {
 
 beforeEach(() => {
     mockPort.updateTotal.mockReset();
-    mockPort.updateTotal.mockResolvedValue(true);
+    mockPort.updateTotal.mockResolvedValue([]);
 });
 
 describe.each([
@@ -494,10 +494,15 @@ describe.each([
     });
 });
 
-test("throws an error if update to totals fails", async () => {
-    mockPort.updateTotal.mockResolvedValue(false);
+test("throws an error if update to totals returns item failures", async () => {
+    const occurrence = createOccurrence(VALID_URL, "test", 15, false);
+    mockPort.updateTotal.mockResolvedValue([occurrence]);
     const event = createEvent([
-        createOccurrenceInsertRecord(VALID_URL, "test", 15),
+        createOccurrenceInsertRecord(
+            VALID_URL,
+            occurrence.keyphrase,
+            occurrence.occurrences
+        ),
     ]);
 
     expect.assertions(1);

--- a/services/keyphrase/functions/total-occurrences/ports/TotalOccurrencesPort.ts
+++ b/services/keyphrase/functions/total-occurrences/ports/TotalOccurrencesPort.ts
@@ -1,4 +1,7 @@
-import { SiteKeyphraseOccurrences } from "buzzword-keyphrase-keyphrase-repository-library";
+import {
+    SiteKeyphrase,
+    SiteKeyphraseOccurrences,
+} from "buzzword-keyphrase-keyphrase-repository-library";
 
 type OccurrenceTotalImage = {
     baseURL?: string;
@@ -15,7 +18,9 @@ type OccurrenceItem = ItemState<SiteKeyphraseOccurrences>;
 type TotalItem = ItemState<OccurrenceTotalImage>;
 
 interface TotalOccurrencesPort {
-    updateTotal(items: (OccurrenceItem | TotalItem)[]): Promise<boolean>;
+    updateTotal(
+        items: (OccurrenceItem | TotalItem)[]
+    ): Promise<SiteKeyphrase[]>;
 }
 
 export {

--- a/services/keyphrase/keyphrase-template.yml
+++ b/services/keyphrase/keyphrase-template.yml
@@ -436,6 +436,8 @@ Resources:
                         BatchSize: 10
                         StartingPosition: TRIM_HORIZON
                         MaximumRetryAttempts: 5
+                        FunctionResponseTypes:
+                            - ReportBatchItemFailures
             Architectures:
                 - arm64
             Environment:
@@ -507,6 +509,8 @@ Resources:
                         FilterCriteria:
                             Filters:
                                 - Pattern: '{ "dynamodb": { "Keys": { "pk": { "S": [ { "anything-but": [ "TOTAL" ] } ] } } } }'
+                        FunctionResponseTypes:
+                            - ReportBatchItemFailures
             Architectures:
                 - arm64
             Environment:
@@ -670,6 +674,8 @@ Resources:
                         FilterCriteria:
                             Filters:
                                 - Pattern: '{ "dynamodb": { "Keys": { "pk": { "S": [ { "anything-but": [ "TOTAL" ] } ] } } } }'
+                        FunctionResponseTypes:
+                            - ReportBatchItemFailures
             Architectures:
                 - arm64
             Environment:

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -179,7 +179,7 @@ class KeyphraseRepository implements Repository {
 
             return (await Promise.all(promises)).filter(
                 (occurrence): occurrence is SiteKeyphraseOccurrences =>
-                    occurrence !== null
+                    occurrence != undefined
             );
         }
 
@@ -203,7 +203,8 @@ class KeyphraseRepository implements Repository {
             });
 
             return (await Promise.all(promises)).filter(
-                (keyphrase): keyphrase is SiteKeyphrase => keyphrase !== null
+                (keyphrase): keyphrase is SiteKeyphrase =>
+                    keyphrase != undefined
             );
         }
 

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -157,15 +157,33 @@ class KeyphraseRepository implements Repository {
         return this.storeIndividualKeyphrase(item);
     }
 
+    addOccurrencesToTotals(
+        occurrences: SiteKeyphraseOccurrences
+    ): Promise<boolean>;
+    addOccurrencesToTotals(
+        occurrences: SiteKeyphraseOccurrences[]
+    ): Promise<Omit<SiteKeyphraseOccurrences, "occurrences" | "aggregated">[]>;
+
     async addOccurrencesToTotals(
-        items: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
-    ): Promise<boolean> {
-        if (Array.isArray(items)) {
-            const promises = items.map((item) => this.addItemToTotal(item));
-            return (await Promise.all(promises)).every(Boolean);
+        occurrences: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
+    ): Promise<
+        boolean | Omit<SiteKeyphraseOccurrences, "occurrences" | "aggregated">[]
+    > {
+        if (Array.isArray(occurrences)) {
+            const promises = occurrences.map(async (occurrence) => {
+                const success = await this.addItemToTotal(occurrence);
+                if (!success) {
+                    return occurrence;
+                }
+            });
+
+            return (await Promise.all(promises)).filter(
+                (occurrence): occurrence is SiteKeyphraseOccurrences =>
+                    occurrence !== null
+            );
         }
 
-        return this.addItemToTotal(items);
+        return this.addItemToTotal(occurrences);
     }
 
     async setKeyphraseAggregated(

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/KeyphraseRepository.ts
@@ -186,14 +186,25 @@ class KeyphraseRepository implements Repository {
         return this.addItemToTotal(occurrences);
     }
 
+    setKeyphraseAggregated(keyphrase: SiteKeyphrase): Promise<boolean>;
+    setKeyphraseAggregated(
+        keyphrases: SiteKeyphrase[]
+    ): Promise<SiteKeyphrase[]>;
+
     async setKeyphraseAggregated(
         keyphrases: SiteKeyphrase | SiteKeyphrase[]
-    ): Promise<boolean> {
+    ): Promise<boolean | SiteKeyphrase[]> {
         if (Array.isArray(keyphrases)) {
-            const promises = keyphrases.map((keyphrase) =>
-                this.setAggregatedFlag(keyphrase)
+            const promises = keyphrases.map(async (keyphrase) => {
+                const success = await this.setAggregatedFlag(keyphrase);
+                if (!success) {
+                    return keyphrase;
+                }
+            });
+
+            return (await Promise.all(promises)).filter(
+                (keyphrase): keyphrase is SiteKeyphrase => keyphrase !== null
             );
-            return (await Promise.all(promises)).every(Boolean);
         }
 
         return this.setAggregatedFlag(keyphrases);

--- a/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/adapters/__tests__/KeyphraseRepository.test.ts
@@ -56,6 +56,14 @@ function createRandomOccurrences(
 
 function createOccurrenceItem(
     url: URL,
+    keyphraseOccurrence: KeyphraseOccurrences
+): SiteKeyphraseOccurrences;
+function createOccurrenceItem(
+    url: URL,
+    keyphraseOccurrences: KeyphraseOccurrences[]
+): SiteKeyphraseOccurrences[];
+function createOccurrenceItem(
+    url: URL,
     keyphraseOccurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
 ): SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[] {
     if (Array.isArray(keyphraseOccurrences)) {
@@ -527,17 +535,47 @@ describe("total handling", () => {
         await repository.empty();
     });
 
+    describe("new total storage given a single item", () => {
+        const occurrence = TEST_KEYPHRASES[0];
+        const total = createOccurrenceItem(VALID_URL, occurrence);
+
+        beforeEach(async () => {
+            await repository.storeKeyphrases(
+                VALID_URL.hostname,
+                VALID_URL.pathname,
+                occurrence
+            );
+        });
+
+        test("returns success when total storage succeeds", async () => {
+            const actual = await repository.addOccurrencesToTotals(total);
+
+            expect(actual).toBe(true);
+        });
+
+        test("stores site totals successfully", async () => {
+            await repository.addOccurrencesToTotals(total);
+
+            const stored = await repository.getTotals(VALID_URL.hostname);
+
+            expect(stored).toEqual(expect.arrayContaining([occurrence]));
+        });
+
+        test("stores global total successfully", async () => {
+            await repository.addOccurrencesToTotals(total);
+
+            const stored = await repository.getTotals();
+
+            expect(stored).toEqual(expect.arrayContaining([occurrence]));
+        });
+    });
+
     describe.each([
-        ["a single item", TEST_KEYPHRASES[0], [TEST_KEYPHRASES[0]]],
         ["less than 25 items", TEST_KEYPHRASES, TEST_KEYPHRASES],
         ["greater than 25 items", TEST_BATCH_KEYPHRASES, TEST_BATCH_KEYPHRASES],
     ])(
         "new total storage given %s",
-        (
-            message: string,
-            occurrences: KeyphraseOccurrences | KeyphraseOccurrences[],
-            expected: KeyphraseOccurrences[]
-        ) => {
+        (message: string, occurrences: KeyphraseOccurrences[]) => {
             const items = createOccurrenceItem(VALID_URL, occurrences);
 
             beforeEach(async () => {
@@ -548,10 +586,10 @@ describe("total handling", () => {
                 );
             });
 
-            test("returns success when total storage succeeds", async () => {
+            test("returns no failed items when total storage succeeds", async () => {
                 const actual = await repository.addOccurrencesToTotals(items);
 
-                expect(actual).toBe(true);
+                expect(actual).toEqual([]);
             });
 
             test("stores site totals successfully", async () => {
@@ -559,41 +597,48 @@ describe("total handling", () => {
 
                 const stored = await repository.getTotals(VALID_URL.hostname);
 
-                expect(stored).toEqual(expect.arrayContaining(expected));
+                expect(stored).toEqual(expect.arrayContaining(occurrences));
             });
 
-            test("stores global total successfully", async () => {
+            test("stores global totals successfully", async () => {
                 await repository.addOccurrencesToTotals(items);
 
                 const stored = await repository.getTotals();
 
-                expect(stored).toEqual(expect.arrayContaining(expected));
+                expect(stored).toEqual(expect.arrayContaining(occurrences));
             });
         }
     );
 
-    test.each([
-        ["a single item", TEST_KEYPHRASES[0]],
-        ["multiple items", TEST_KEYPHRASES],
-    ])(
-        "returns success given %s that have been totalled before",
-        async (
-            message: string,
-            occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
-        ) => {
-            const items = createOccurrenceItem(VALID_URL, occurrences);
-            await repository.storeKeyphrases(
-                VALID_URL.hostname,
-                VALID_URL.pathname,
-                occurrences
-            );
-            await repository.addOccurrencesToTotals(items);
+    test("returns success given storage succeeds for a single item that has been totalled before", async () => {
+        const occurrence = TEST_KEYPHRASES[0];
+        const total = createOccurrenceItem(VALID_URL, occurrence);
+        await repository.storeKeyphrases(
+            VALID_URL.hostname,
+            VALID_URL.pathname,
+            occurrence
+        );
+        await repository.addOccurrencesToTotals(total);
 
-            const actual = await repository.addOccurrencesToTotals(items);
+        const actual = await repository.addOccurrencesToTotals(total);
 
-            expect(actual).toBe(true);
-        }
-    );
+        expect(actual).toBe(true);
+    });
+
+    test("returns no failed items given storage succeeds for multiple items that have been totalled before", async () => {
+        const occurrences = TEST_KEYPHRASES;
+        const totals = createOccurrenceItem(VALID_URL, occurrences);
+        await repository.storeKeyphrases(
+            VALID_URL.hostname,
+            VALID_URL.pathname,
+            occurrences
+        );
+        await repository.addOccurrencesToTotals(totals);
+
+        const actual = await repository.addOccurrencesToTotals(totals);
+
+        expect(actual).toEqual([]);
+    });
 
     describe("existing total storage", () => {
         test("does not increment site total given item has already been added to total", async () => {
@@ -710,18 +755,18 @@ describe("total handling", () => {
         expect(actual).toBe(false);
     });
 
-    test("returns failure when storage fails given multiple totals", async () => {
+    test("returns all provided totals when storage fails given multiple totals", async () => {
+        const occurrences = TEST_KEYPHRASES;
+        const expected = createOccurrenceItem(VALID_URL, occurrences);
         const putItemSpy = jest.spyOn(dynamoDB, "transactWriteItems");
         putItemSpy.mockImplementation(() => {
             throw new Error("test error");
         });
 
-        const actual = await repository.addOccurrencesToTotals(
-            createOccurrenceItem(VALID_URL, TEST_KEYPHRASES)
-        );
+        const actual = await repository.addOccurrencesToTotals(expected);
         putItemSpy.mockRestore();
 
-        expect(actual).toBe(false);
+        expect(actual).toEqual(expected);
     });
 
     test.each([
@@ -911,16 +956,47 @@ describe("empty table behaviour", () => {
         }
     );
 
+    describe("empty clears all totals given a single total stored", () => {
+        const occurrence = TEST_KEYPHRASES[0];
+
+        beforeEach(async () => {
+            await repository.storeKeyphrases(
+                VALID_URL.hostname,
+                VALID_URL.pathname,
+                occurrence
+            );
+            await repository.addOccurrencesToTotals(
+                createOccurrenceItem(VALID_URL, occurrence)
+            );
+        });
+
+        test("returns success", async () => {
+            const actual = await repository.empty();
+
+            expect(actual).toBe(true);
+        });
+
+        test("empties table of site totals", async () => {
+            await repository.empty();
+            const actual = await repository.getTotals(VALID_URL.hostname);
+
+            expect(actual).toHaveLength(0);
+        });
+
+        test("empties table of global totals", async () => {
+            await repository.empty();
+            const actual = await repository.getTotals();
+
+            expect(actual).toHaveLength(0);
+        });
+    });
+
     describe.each([
-        ["a single total", TEST_KEYPHRASES[0]],
         ["less than 25 totals", TEST_KEYPHRASES],
         ["more than 25 totals", TEST_BATCH_KEYPHRASES],
     ])(
         "Empty clears all totals given %s stored",
-        (
-            message: string,
-            occurrences: KeyphraseOccurrences | KeyphraseOccurrences[]
-        ) => {
+        (message: string, occurrences: KeyphraseOccurrences[]) => {
             beforeEach(async () => {
                 await repository.storeKeyphrases(
                     VALID_URL.hostname,

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -32,8 +32,11 @@ interface Repository {
     ): Promise<boolean>;
     getTotals(baseURL?: string): Promise<KeyphraseOccurrences[]>;
     addOccurrencesToTotals(
-        occurrences: SiteKeyphraseOccurrences | SiteKeyphraseOccurrences[]
+        occurrences: SiteKeyphraseOccurrences
     ): Promise<boolean>;
+    addOccurrencesToTotals(
+        occurrences: SiteKeyphraseOccurrences[]
+    ): Promise<Omit<SiteKeyphraseOccurrences, "occurrences" | "aggregated">[]>;
     getKeyphraseUsages(keyphrase: string): Promise<string[]>;
     setKeyphraseAggregated(
         keyphrases: SiteKeyphrase | SiteKeyphrase[]

--- a/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
+++ b/services/keyphrase/libs/keyphrase-repository-library/ports/Repository.ts
@@ -38,9 +38,10 @@ interface Repository {
         occurrences: SiteKeyphraseOccurrences[]
     ): Promise<Omit<SiteKeyphraseOccurrences, "occurrences" | "aggregated">[]>;
     getKeyphraseUsages(keyphrase: string): Promise<string[]>;
+    setKeyphraseAggregated(keyphrase: SiteKeyphrase): Promise<boolean>;
     setKeyphraseAggregated(
-        keyphrases: SiteKeyphrase | SiteKeyphrase[]
-    ): Promise<boolean>;
+        keyphrases: SiteKeyphrase[]
+    ): Promise<SiteKeyphrase[]>;
 }
 
 export {


### PR DESCRIPTION
Resolves #375 

# What

Updated all DynamoDB stream event source mappings to include `ReportBatchItemFailures` response types
Updated total occurrence lambda to return relevant sequence numbers when total update fails 

# Why

Response Type:
- Required to enable the partial batch item failure response type for lambda functions: https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html#services-ddb-batchfailurereporting

Partial failures:
- To reduce the amount of duplicate processing that occurs when the total occurrence lambda hits rate limits or other errors