### PR TITLE
test/improve lazy load test stability

### DIFF
--- a/ui/src/components/__tests__/App.test.tsx
+++ b/ui/src/components/__tests__/App.test.tsx
@@ -76,10 +76,12 @@ describe("navigating to results with valid encoded URL", () => {
             <App keyphraseServiceClientFactory={mockKeyphraseClientFactory} />
         );
 
-        await waitFor(() =>
-            expect(
-                getByRole("heading", { name: expectedResultsHeader })
-            ).toBeInTheDocument()
+        await waitFor(
+            () =>
+                expect(
+                    getByRole("heading", { name: expectedResultsHeader })
+                ).toBeInTheDocument(),
+            { timeout: 3000 }
         );
         expect(
             getByRole("heading", { name: APPLICATION_TITLE })
@@ -136,10 +138,12 @@ test("navigates to results page if crawl successfully completes", async () => {
     });
     fireEvent.submit(getByRole("button", { name: SEARCH_BUTTON_TEXT }));
 
-    await waitFor(() =>
-        expect(
-            getByRole("heading", { name: expectedHeader })
-        ).toBeInTheDocument()
+    await waitFor(
+        () =>
+            expect(
+                getByRole("heading", { name: expectedHeader })
+            ).toBeInTheDocument(),
+        { timeout: 3000 }
     );
 });
 


### PR DESCRIPTION
# What

Updated `App.test.tsx` tests that load results page to increase the timeout time for waiting for page to load

# Why

Reduce the likelihood that the page has not loaded