### PR TITLE
Ci/cache npm dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,13 @@ jobs:
         uses: ./.github/workflows/package.yml
         with:
             path: ./packages/object-validator
+            node_cache_key: object-validator
     build-deploy-crawl-client-package:
         name: Crawl Client Package
         uses: ./.github/workflows/package.yml
         with:
             path: ./packages/crawl-client
+            node_cache_key: crawl-client
     build-deploy-crawl-service:
         name: Crawl Service
         uses: ./.github/workflows/service.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,17 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              env:
+                  cache-name: ci-lint
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ env.cache-name }}-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ env.cache-name }}-
             - name: Install Dependencies
               run: |
                   npx lerna bootstrap --scope "{how-many-buzzwords,how-many-buzzwords-ui}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,6 +22,7 @@ jobs:
                   filters: |
                       package:
                           - ${{ inputs.path }}/**
+                          - ./.github/workflows/package.yml
     compile:
         runs-on: ubuntu-latest
         needs: changed

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,8 +36,9 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: |
+                      ./node_modules
                       ${{ inputs.path }}/**/node_modules
-                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Compile Package
@@ -78,8 +79,9 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: |
+                      ./node_modules
                       ${{ inputs.path }}/**/node_modules
-                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Install Dependencies
@@ -103,8 +105,9 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: |
+                      ./node_modules
                       ${{ inputs.path }}/**/node_modules
-                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Install Dependencies
@@ -129,8 +132,9 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: |
+                      ./node_modules
                       ${{ inputs.path }}/**/node_modules
-                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Compile Package

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,9 @@ on:
             path:
                 required: true
                 type: string
+            node_cache_key:
+                required: true
+                type: string
 
 jobs:
     changed:
@@ -28,6 +31,14 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Compile Package
               run: |
                   ./scripts/helpers/compile-package.sh -c -p ${{ inputs.path }}
@@ -62,6 +73,14 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Install Dependencies
               run: |
                   package_name=$(jq -r ".name" ${{ inputs.path }}/package.json)
@@ -79,6 +98,14 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Install Dependencies
               run: |
                   package_name=$(jq -r ".name" ${{ inputs.path }}/package.json)
@@ -97,6 +124,14 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.node_cache_key }}-
             - name: Compile Package
               run: |
                   ./scripts/helpers/compile-package.sh -c -p ${{ inputs.path }}

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -40,6 +40,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
             - name: Compile Package
               run: |
                   ./scripts/helpers/compile-service.sh -c -p ${{ inputs.path }}
@@ -84,6 +93,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
             - name: Install Dependencies
               run: |
                   package_name=$(jq -r ".name" ${{ inputs.path }}/package.json)
@@ -115,6 +133,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
             - name: Install Dependencies
               run: |
                   package_name=$(jq -r ".name" ${{ inputs.path }}/package.json)
@@ -135,6 +162,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
             - name: Install Dependencies
               run: |
                   package_name=$(jq -r ".name" ${{ inputs.path }}/package.json)
@@ -181,6 +217,15 @@ jobs:
               with:
                   aws-region: eu-west-2
                   role-to-assume: ${{ secrets.deploy_role }}
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
             - name: Cache deployment packages
               uses: actions/cache@v3
               env:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -49,6 +49,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
             - name: Build UI
               run: |
                   npm --prefix ${{ inputs.path }} run build
@@ -79,6 +88,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
             - name: Install Dependencies
               run: |
                   npm --prefix ${{ inputs.path }} run ci
@@ -99,6 +117,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
             - name: Install Dependencies
               run: |
                   npm --prefix ${{ inputs.path }} run ci
@@ -118,6 +145,15 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
             - name: Install Dependencies
               run: |
                   npm --prefix ${{ inputs.path }} run ci
@@ -159,6 +195,15 @@ jobs:
               with:
                   aws-region: eu-west-2
                   role-to-assume: ${{ secrets.DEPLOY_ROLE }}
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
             - name: Deploy stack
               run: |
                   ./scripts/deploy-ui.sh -e production -f -c

--- a/scripts/helpers/compile-package.sh
+++ b/scripts/helpers/compile-package.sh
@@ -33,6 +33,7 @@ if [ -z $path ]; then
 fi
 
 root_dir="$( dirname "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+package_name=$(jq -r ".name" $path/package.json)
 
 if [ -z $output_path ]; then
     output_path="$root_dir/dist"
@@ -41,11 +42,9 @@ fi
 if [ $clean ]; then
     echo "Clean installing..."
     rm -rf $output_path
-    npm --prefix $root_dir ci
-    npm --prefix $path ci
+    npx lerna bootstrap --scope "{how-many-buzzwords,$package_name}" --ci
 else 
-    npm --prefix $root_dir i
-    npm --prefix $path i
+    npx lerna bootstrap --scope "{how-many-buzzwords,$package_name}" --no-ci
 fi
 
 if [ -f $path/tsconfig.build.json ]; then


### PR DESCRIPTION
# What

Updated all CI pipeline configs to cache `node_modules`
- Key dependent on hash of `package-lock.json `of relevant packages

Updated `compile-package.sh` to use Lerna rather than npm directly

# Why

To speed up the overall time to run the CI pipeline
- Improving feedback loop and overall deployment times