### PR TITLE
Feature/555 deploy dry run

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -101,6 +101,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: "18"
+            - uses: SimenB/github-actions-cpu-cores@v1
+              id: cpu-cores
             - name: Cache Node Dependencies
               uses: actions/cache@v3
               with:
@@ -116,7 +118,7 @@ jobs:
                   npx lerna bootstrap --scope "{how-many-buzzwords,$package_name}"
             - name: Run Unit Tests
               run: |
-                  ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose
+                  ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --max-workers ${{ steps.cpu-cores.outputs.count }}
     publish:
         runs-on: ubuntu-latest
         needs: [compile, audit, format, lint, unit-test]

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -157,6 +157,8 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - uses: SimenB/github-actions-cpu-cores@v1
+              id: cpu-cores
             - name: Cache Node Dependencies
               uses: actions/cache@v3
               with:
@@ -174,7 +176,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Run Unit Tests
               run: |
-                  npm run test:unit -- --testPathPattern=${{ inputs.path }}
+                  npm run test:unit -- --testPathPattern=${{ inputs.path }} --max-workers ${{ steps.cpu-cores.outputs.count }}
     integration-test:
         runs-on: ubuntu-latest
         needs: changed
@@ -186,6 +188,8 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - uses: SimenB/github-actions-cpu-cores@v1
+              id: cpu-cores
             - name: Cache Node Dependencies
               uses: actions/cache@v3
               with:
@@ -208,7 +212,7 @@ jobs:
                   cors: "*"
             - name: Run Integration Tests
               run: |
-                  npm run test:integration -- --testPathPattern=${{ inputs.path }}
+                  npm run test:integration -- --testPathPattern=${{ inputs.path }} --max-workers ${{ steps.cpu-cores.outputs.count }}
     deploy:
         runs-on: ubuntu-latest
         needs:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -14,6 +14,9 @@ on:
             deploy_role:
                 required: true
 
+env:
+    deployment_cache_name: cache-deployment-packages
+
 jobs:
     changed:
         runs-on: ubuntu-latest
@@ -29,17 +32,29 @@ jobs:
                       service:
                           - ${{ inputs.path }}/**
                           - ./.github/workflows/service.yml
-    compile:
+    deploy-dryrun:
         runs-on: ubuntu-latest
         needs: changed
         if: ${{ needs.changed.outputs.service == 'true' }}
+        permissions:
+            id-token: write
+            contents: read
+            packages: read
         steps:
             - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.8"
             - uses: actions/setup-node@v3
               with:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - uses: aws-actions/setup-sam@v2
+            - uses: aws-actions/configure-aws-credentials@v1-node16
+              with:
+                  aws-region: eu-west-2
+                  role-to-assume: ${{ secrets.deploy_role }}
             - name: Cache Node Dependencies
               uses: actions/cache@v3
               with:
@@ -49,9 +64,18 @@ jobs:
                   key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
-            - name: Compile Package
+            - name: Cache deployment packages
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      .aws-sam/cache/**
+                      .aws-sam/build.toml
+                  key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  restore-keys: |
+                      ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-
+            - name: Dry Run Deployment
               run: |
-                  ./scripts/helpers/compile-service.sh -c -p ${{ inputs.path }}
+                  ${{ inputs.deploy_script_path }} -e production -d
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     audit:
@@ -189,7 +213,7 @@ jobs:
         runs-on: ubuntu-latest
         needs:
             [
-                compile,
+                deploy-dryrun,
                 audit,
                 format,
                 lint,
@@ -228,15 +252,13 @@ jobs:
                       ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
             - name: Cache deployment packages
               uses: actions/cache@v3
-              env:
-                  cache-name: cache-deployment-packages
               with:
                   path: |
                       .aws-sam/cache/**
                       .aws-sam/build.toml
-                  key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.cache-name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
                   restore-keys: |
-                      ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.cache-name }}-
+                      ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-
             - name: Deploy stack
               run: |
                   ${{ inputs.deploy_script_path }} -e production

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -38,17 +38,29 @@ jobs:
                   npm audit --audit-level=critical --prefix ${{ inputs.path }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    build:
+    deploy-dryrun:
         runs-on: ubuntu-latest
         needs: changed
         if: ${{ needs.changed.outputs.ui == 'true' }}
+        permissions:
+            id-token: write
+            contents: read
+            packages: read
         steps:
             - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.8"
             - uses: actions/setup-node@v3
               with:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - uses: aws-actions/setup-sam@v2
+            - uses: aws-actions/configure-aws-credentials@v1-node16
+              with:
+                  aws-region: eu-west-2
+                  role-to-assume: ${{ secrets.DEPLOY_ROLE }}
             - name: Cache Node Dependencies
               uses: actions/cache@v3
               with:
@@ -58,9 +70,9 @@ jobs:
                   key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
                   restore-keys: |
                       ${{ runner.os }}-node-v1-ui-
-            - name: Build UI
+            - name: Dry Run Deployment
               run: |
-                  npm --prefix ${{ inputs.path }} run build
+                  ./scripts/deploy-ui.sh -e production -d -c
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     format:
@@ -174,7 +186,15 @@ jobs:
                   retention-days: 5
     deploy:
         runs-on: ubuntu-latest
-        needs: [audit, build, format, lint, unit-test, browser-component-test]
+        needs:
+            [
+                audit,
+                deploy-dryrun,
+                format,
+                lint,
+                unit-test,
+                browser-component-test,
+            ]
         if: ${{ github.ref == 'refs/heads/master' }}
         permissions:
             id-token: write

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -129,6 +129,8 @@ jobs:
                   node-version: "18"
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
+            - uses: SimenB/github-actions-cpu-cores@v1
+              id: cpu-cores
             - name: Cache Node Dependencies
               uses: actions/cache@v3
               with:
@@ -145,7 +147,7 @@ jobs:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - name: Run Unit Tests
               run: |
-                  ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose
+                  ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --max-workers ${{ steps.cpu-cores.outputs.count }}
     browser-component-test:
         runs-on: ubuntu-latest
         needs: changed

--- a/scripts/deploy-crawl-service.sh
+++ b/scripts/deploy-crawl-service.sh
@@ -2,14 +2,18 @@
 
 usage() {
     echo "Usage:
-    -e [Environment to deploy]" 1>&2;
+    -e [Environment to deploy]
+    -d [Dry run flag]" 1>&2;
     exit 1;
 }
 
-while getopts "e:h" opt; do
+while getopts "e:dh" opt; do
     case $opt in
         e)
             environment=$OPTARG
+            ;;
+        d)
+            dryrun=true
             ;;
         h)
             usage
@@ -54,10 +58,17 @@ fi
 
 api_key_expiry="$(date -d "+365 days" "+%s")"
 
+deploy_optional_params=()
+if [ $dryrun ]; then
+    deploy_optional_params+=(-d)
+else
+    deploy_optional_params+=(-f)
+fi
+
 $script_dir/helpers/deploy-service.sh \
     -t $template_path \
     -c $config_path \
     -e $environment \
-    -f \
     -o "APIKeyExpiryTime=$api_key_expiry $config_parameters" \
-    --cache
+    --cache \
+    "${deploy_optional_params[@]}"

--- a/scripts/deploy-keyphrase-service.sh
+++ b/scripts/deploy-keyphrase-service.sh
@@ -2,14 +2,18 @@
 
 usage() {
     echo "Usage:
-    -e [Environment to deploy]" 1>&2;
+    -e [Environment to deploy]
+    -d [Dry run flag]" 1>&2;
     exit 1;
 }
 
-while getopts "e:h" opt; do
+while getopts "e:dh" opt; do
     case $opt in
         e)
             environment=$OPTARG
+            ;;
+        d)
+            dryrun=true
             ;;
         h)
             usage
@@ -80,10 +84,17 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+deploy_optional_params=()
+if [ $dryrun ]; then
+    deploy_optional_params+=(-d)
+else
+    deploy_optional_params+=(-f)
+fi
+
 $script_dir/helpers/deploy-service.sh \
     -t $template_path \
     -c $config_path \
     -e $environment \
-    -f \
     -o "CrawlEventBusARN=$crawl_event_bus_arn CrawlRESTEndpoint=$crawl_rest_endpoint $config_parameters" \
-    --cache
+    --cache \
+    "${deploy_optional_params[@]}"

--- a/scripts/helpers/deploy-service.sh
+++ b/scripts/helpers/deploy-service.sh
@@ -6,12 +6,13 @@ usage() {
     -c [Mandatory: Path to config file]
     -e [Mandatory: Environment to deploy]
     -f [Force deployment flag]
+    -d [Dry run flag]
     -o [Environment parameter overrides]
     --cache [Cache build flag]" 1>&2;
     exit 1; 
 }
 
-while getopts "t:c:e:fo:-:h" opt; do
+while getopts "t:c:e:fdo:-:h" opt; do
     if [ $opt = "-" ]; then
         opt="${OPTARG%%=*}"
         OPTARG="${OPTARG#$opt}"
@@ -30,6 +31,9 @@ while getopts "t:c:e:fo:-:h" opt; do
             ;;
         f)
             force=true
+            ;;
+        d)
+            dryrun=true
             ;;
         o)
             overrides=$OPTARG
@@ -60,7 +64,9 @@ fi
 $script_dir/build-stack.sh -t $template "${build_optional_params[@]}"
 
 deploy_optional_params=()
-if [ $force ]; then
+if [ $dryrun ]; then
+    deploy_optional_params+=(-d)
+elif [ $force ]; then
     deploy_optional_params+=(-f)
 fi
 

--- a/scripts/helpers/deploy-stack.sh
+++ b/scripts/helpers/deploy-stack.sh
@@ -5,11 +5,12 @@ usage() {
     -c [Mandatory: Path to config file]
     -e [Mandatory: Environment to deploy]
     -f [Force deployment flag]
+    -d [Dry run flag]
     -o [Environment parameter overrides]" 1>&2;
     exit 1; 
 }
 
-while getopts "c:e:fo:h" opt; do
+while getopts "c:e:fdo:h" opt; do
     case $opt in
         c)
             config=$OPTARG
@@ -19,6 +20,9 @@ while getopts "c:e:fo:h" opt; do
             ;;
         f)
             force=true
+            ;;
+        d)
+            dryrun=true
             ;;
         o)
             overrides=$OPTARG
@@ -37,7 +41,9 @@ if [ -z $config ]; then
 fi
 
 optional_params=()
-if [ $force ]; then
+if [ $dryrun ]; then
+    optional_params+=(--no-execute-changeset)
+elif [ $force ]; then
     optional_params+=(--no-confirm-changeset)
 fi
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -29,7 +29,7 @@
                 "@babel/preset-env": "^7.18.2",
                 "@babel/preset-react": "^7.17.12",
                 "@babel/preset-typescript": "^7.17.12",
-                "@playwright/experimental-ct-react": "1.29.0",
+                "@playwright/experimental-ct-react": "1.29.1",
                 "@testing-library/jest-dom": "^5.16.4",
                 "@testing-library/react": "^13.3.0",
                 "@types/react": "^18.0.9",
@@ -3922,12 +3922,12 @@
             "optional": true
         },
         "node_modules/@playwright/experimental-ct-react": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.29.0.tgz",
-            "integrity": "sha512-Ilf5KSkyIEBX9BbIdF4lCQg1vNjqwHGqNwAHYZe1HyIsFXFZ8m550R2xoMmUEYpaiZketUUerAm7MGnsl7AkIg==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.29.1.tgz",
+            "integrity": "sha512-6kdeVpDoI8afM6fR66idRKWIdaikID1BZErGIru3j7eFpRkw5PGJR60+aZRE1Nb84JrKxajZrqULkZbUJyBrIA==",
             "dev": true,
             "dependencies": {
-                "@playwright/test": "1.29.0",
+                "@playwright/test": "1.29.1",
                 "@vitejs/plugin-react": "^2.2.0",
                 "vite": "^3.2.1"
             },
@@ -3936,13 +3936,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.0.tgz",
-            "integrity": "sha512-gp5PVBenxTJsm2bATWDNc2CCnrL5OaA/MXQdJwwkGQtqTjmY+ZOqAdLqo49O9MLTDh2vYh+tHWDnmFsILnWaeA==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
+            "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "playwright-core": "1.29.0"
+                "playwright-core": "1.29.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -14161,9 +14161,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.0.tgz",
-            "integrity": "sha512-pboOm1m0RD6z1GtwAbEH60PYRfF87vKdzOSRw2RyO0Y0a7utrMyWN2Au1ojGvQr4umuBMODkKTv607YIRypDSQ==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
+            "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
             "dev": true,
             "bin": {
                 "playwright": "cli.js"
@@ -21519,24 +21519,24 @@
             "optional": true
         },
         "@playwright/experimental-ct-react": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.29.0.tgz",
-            "integrity": "sha512-Ilf5KSkyIEBX9BbIdF4lCQg1vNjqwHGqNwAHYZe1HyIsFXFZ8m550R2xoMmUEYpaiZketUUerAm7MGnsl7AkIg==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react/-/experimental-ct-react-1.29.1.tgz",
+            "integrity": "sha512-6kdeVpDoI8afM6fR66idRKWIdaikID1BZErGIru3j7eFpRkw5PGJR60+aZRE1Nb84JrKxajZrqULkZbUJyBrIA==",
             "dev": true,
             "requires": {
-                "@playwright/test": "1.29.0",
+                "@playwright/test": "1.29.1",
                 "@vitejs/plugin-react": "^2.2.0",
                 "vite": "^3.2.1"
             }
         },
         "@playwright/test": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.0.tgz",
-            "integrity": "sha512-gp5PVBenxTJsm2bATWDNc2CCnrL5OaA/MXQdJwwkGQtqTjmY+ZOqAdLqo49O9MLTDh2vYh+tHWDnmFsILnWaeA==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
+            "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
-                "playwright-core": "1.29.0"
+                "playwright-core": "1.29.1"
             }
         },
         "@rc-component/portal": {
@@ -29361,9 +29361,9 @@
             }
         },
         "playwright-core": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.0.tgz",
-            "integrity": "sha512-pboOm1m0RD6z1GtwAbEH60PYRfF87vKdzOSRw2RyO0Y0a7utrMyWN2Au1ojGvQr4umuBMODkKTv607YIRypDSQ==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
+            "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
             "dev": true
         },
         "posix-character-classes": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@babel/preset-typescript": "^7.17.12",
-        "@playwright/experimental-ct-react": "1.29.0",
+        "@playwright/experimental-ct-react": "1.29.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "@types/react": "^18.0.9",


### PR DESCRIPTION
Resolves #555 

# What

Updated all deployment scripts to have new `-d` dry run flag that runs deployment up to the point that the CloudFormation change set is produced but does not execute it or deploy any new artefacts to production (UI)

Replaced all build/compile jobs with a dry-run job that executes the updated deployment scripts with `-d` flag

Updated all usages of jest in GitHub Workflows to set the max workers flag to the number of CPU cores of the GitHub Actions worker

# Why

Dry run:
- To ensure that the deployment script will pass before running on master
- Replaced compile/build jobs as the deployment scripts encompasses the tasks performed in these jobs

Max Worker change:
- Was experiencing intermittent issues with pipelines failing due to segmentation faults
- Issue on Jest repo suggests setting max workers as remedy: https://github.com/facebook/jest/issues/10662#issuecomment-923850177
- Jest documentation also states setting max workers as way of speeding up tests so did both at same time: https://jestjs.io/docs/next/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server

