### PR TITLE
Feature/562 changeset pr comment

### DIFF
--- a/.github/comment_template/changeset-template.md
+++ b/.github/comment_template/changeset-template.md
@@ -1,0 +1,11 @@
+## Proposed Changes to Infastructure
+
+### Affected Service
+
+{{ .service_name }}
+
+### Changeset
+
+```
+{{ .changeset }}
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
             service_cache_key: crawl-service
             path: ./services/crawl
             deploy_script_path: ./scripts/deploy-crawl-service.sh
+            service_name: Crawl Service
         secrets:
             deploy_role: ${{ secrets.AWS_DEPLOY_ROLE }}
     build-deploy-keyphrase-service:
@@ -30,6 +31,7 @@ jobs:
             service_cache_key: keyphrase-service
             path: ./services/keyphrase
             deploy_script_path: ./scripts/deploy-keyphrase-service.sh
+            service_name: Keyphrase Service
         secrets:
             deploy_role: ${{ secrets.AWS_DEPLOY_ROLE }}
     build-deploy-ui:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: Validate and Deploy
-on: [push]
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
 
 jobs:
     build-deploy-object-validator-package:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -100,6 +100,11 @@ jobs:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-author: "github-actions[bot]"
                   body-includes: ${{ inputs.service_name }}
+            - name: Create Multiline changeset YAML variable for template
+              run: |
+                  ./scripts/helpers/multiline-string-to-yml.sh -k changeset \
+                    -v "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}" \
+                    -o ./template_vars.yml
             - name: Create comment template
               uses: chuhlomin/render-template@v1.6
               id: template
@@ -107,7 +112,7 @@ jobs:
                   template: .github/comment_template/changeset-template.md
                   vars: |
                       service_name: "${{ inputs.service_name }}"
-                      changeset: "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}"
+                  vars_path: ./template_vars.yml
             - name: Create or update comment
               uses: peter-evans/create-or-update-comment@v2
               with:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -77,6 +77,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-
             - name: Dry Run Deployment
+              id: dry-run
               run: |
                   ./scripts/helpers/write-changeset-to-file.sh -c "${{ inputs.deploy_script_path }} -e production -d" \
                     -f $GITHUB_OUTPUT \
@@ -84,6 +85,8 @@ jobs:
                     -d EOF
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        outputs:
+            CHANGESET_OUTPUT: ${{ steps.dry-run.outputs.CHANGESET_OUTPUT }}
     add-changeset-comment:
         runs-on: ubuntu-latest
         needs: deploy-dryrun

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -75,7 +75,10 @@ jobs:
                       ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-
             - name: Dry Run Deployment
               run: |
-                  ${{ inputs.deploy_script_path }} -e production -d
+                  ./scripts/helpers/write-changeset-to-file.sh -c "${{ inputs.deploy_script_path }} -e production -d" \
+                    -f $GITHUB_OUTPUT \
+                    -v CHANGESET_OUTPUT \
+                    -d EOF
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     audit:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -72,6 +72,7 @@ jobs:
               with:
                   path: |
                       .aws-sam/cache/**
+                      .aws-sam/deps/**
                       .aws-sam/build.toml
                   key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
                   restore-keys: |
@@ -301,6 +302,7 @@ jobs:
               with:
                   path: |
                       .aws-sam/cache/**
+                      .aws-sam/deps/**
                       .aws-sam/build.toml
                   key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
                   restore-keys: |

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -92,6 +92,7 @@ jobs:
         needs: deploy-dryrun
         if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
         steps:
+            - uses: actions/checkout@v3
             - name: Find Comment
               uses: peter-evans/find-comment@v2
               id: find-comment
@@ -99,14 +100,20 @@ jobs:
                   issue-number: ${{ github.event.pull_request.number }}
                   comment-author: "github-actions[bot]"
                   body-includes: ${{ inputs.service_name }}
+            - name: Create comment template
+              uses: chuhlomin/render-template@v1.6
+              id: template
+              with:
+                  template: .github/comment_template/changeset-template.md
+                  vars: |
+                      service_name: "${{ inputs.service_name }}"
+                      changeset: "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}"
             - name: Create or update comment
               uses: peter-evans/create-or-update-comment@v2
               with:
-                  comment-id: ${{ steps.fc.outputs.comment-id }}
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
                   issue-number: ${{ github.event.pull_request.number }}
-                  body: |
-                      ${{ inputs.service_name }}
-                      ${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}
+                  body: ${{ steps.template.outputs.result }}
                   edit-mode: replace
     audit:
         runs-on: ubuntu-latest

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -10,6 +10,9 @@ on:
             deploy_script_path:
                 required: true
                 type: string
+            service_name:
+                required: true
+                type: string
         secrets:
             deploy_role:
                 required: true
@@ -81,6 +84,27 @@ jobs:
                     -d EOF
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    add-changeset-comment:
+        runs-on: ubuntu-latest
+        needs: deploy-dryrun
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
+        steps:
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: ${{ inputs.service_name }}
+            - name: Create or update comment
+              uses: peter-evans/create-or-update-comment@v2
+              with:
+                  comment-id: ${{ steps.fc.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: |
+                      ${{ inputs.service_name }}
+                      ${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}
+                  edit-mode: replace
     audit:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -72,7 +72,10 @@ jobs:
                       ${{ runner.os }}-node-v1-ui-
             - name: Dry Run Deployment
               run: |
-                  ./scripts/deploy-ui.sh -e production -d -c
+                  ./scripts/helpers/write-changeset-to-file.sh -c "./scripts/deploy-ui.sh -e production -d -c" \
+                    -f $GITHUB_OUTPUT \
+                    -v CHANGESET_OUTPUT \
+                    -d EOF
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     format:

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -71,6 +71,7 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-node-v1-ui-
             - name: Dry Run Deployment
+              id: dry-run
               run: |
                   ./scripts/helpers/write-changeset-to-file.sh -c "./scripts/deploy-ui.sh -e production -d -c" \
                     -f $GITHUB_OUTPUT \
@@ -78,6 +79,41 @@ jobs:
                     -d EOF
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        outputs:
+            CHANGESET_OUTPUT: ${{ steps.dry-run.outputs.CHANGESET_OUTPUT }}
+    add-changeset-comment:
+        runs-on: ubuntu-latest
+        needs: deploy-dryrun
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: "How Many Buzzwords UI"
+            - name: Create Multiline changeset YAML variable for template
+              run: |
+                  ./scripts/helpers/multiline-string-to-yml.sh -k changeset \
+                    -v "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}" \
+                    -o ./template_vars.yml
+            - name: Create comment template
+              uses: chuhlomin/render-template@v1.6
+              id: template
+              with:
+                  template: .github/comment_template/changeset-template.md
+                  vars: |
+                      service_name: "How Many Buzzwords UI"
+                  vars_path: ./template_vars.yml
+            - name: Create or update comment
+              uses: peter-evans/create-or-update-comment@v2
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: ${{ steps.template.outputs.result }}
+                  edit-mode: replace
     format:
         runs-on: ubuntu-latest
         needs: changed

--- a/scripts/helpers/multiline-string-to-yml.sh
+++ b/scripts/helpers/multiline-string-to-yml.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage:
+    -k [Mandatory: YML Key]
+    -v [Mandatory: YML Value]
+    -o [Mandatory: Output path]" 1>&2;
+    exit 1; 
+}
+
+while getopts "k:v:o:h" opt; do
+    case $opt in
+        k)
+            key=$OPTARG
+            ;;
+        v)
+            value=$OPTARG
+            ;;
+        o)
+            output=$OPTARG
+            ;;
+        h)
+            usage
+            ;;
+        ?)
+            usage
+            ;;
+    esac
+done
+
+if [[ -z $key ]] || [[ -z $value ]] || [[ -z $output ]]; then
+    usage 
+fi
+
+echo "$key: |
+$(echo "$value" | sed 's/^/  /')" > $output

--- a/scripts/helpers/multiline-string-to-yml.sh
+++ b/scripts/helpers/multiline-string-to-yml.sh
@@ -32,5 +32,5 @@ if [[ -z $key ]] || [[ -z $value ]] || [[ -z $output ]]; then
     usage 
 fi
 
-echo "$key: |
-$(echo "$value" | sed 's/^/  /')" > $output
+echo -n "$key: |
+$(echo "$value" | sed -e 's/[ \t]*$//' -e 's/^/  /')" > $output

--- a/scripts/helpers/write-changeset-to-file.sh
+++ b/scripts/helpers/write-changeset-to-file.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+usage() {
+    echo "Usage:
+    -c [Mandatory: Command to execute]
+    -f [Mandatory: File path to write changeset to]
+    -v [Variable prefix, Mandatory if delimeter provided]
+    -d [Variable delimeter, Mandatory if prefix provided]" 1>&2;
+    exit 1; 
+}
+
+while getopts "c:f:v:d:h" opt; do
+    case $opt in
+        c)
+            command=$OPTARG
+            ;;
+        f)
+            filepath=$OPTARG
+            ;;
+        v)
+            variable_name=$OPTARG
+            ;;
+        d)
+            delimeter=$OPTARG
+            ;;
+        h)
+            usage
+            ;;
+        ?)
+            usage
+            ;;
+    esac
+done
+
+if [[ -z $command ]] || [[ -z $filepath ]]; then
+    usage 
+fi
+
+if [[ $delimeter ]] && [[ -z $variable_name ]]; then
+    usage
+fi
+
+if [[ $variable_name ]] && [[ -z $delimeter ]]; then
+    usage
+fi 
+
+exec 5>&1
+set -e -o pipefail
+
+output=$(bash -c "$command" | tee >(cat - >&5))
+
+set +e +o pipefail
+
+changeset_start_text="CloudFormation stack changeset"
+changeset_end_text="Changeset created successfully"
+
+changeset=$(echo "$output" | sed -n "/$changeset_start_text/,/$changeset_end_text/{/$changeset_end_text/!p;}")
+
+if [[ -z $changeset ]]; then
+    exit 0
+fi
+
+if [[ $variable_name ]] && [[ $delimeter ]]; then
+    echo "$variable_name<<$delimeter" >> $filepath
+fi
+
+echo "$changeset" >> $filepath
+
+if [[ $variable_name ]] && [[ $delimeter ]]; then
+    echo "$delimeter" >> $filepath
+fi


### PR DESCRIPTION
Resolves #562 

# What

Updated service.yml and ui.yml to add change set comment to open PRs if there are any proposed changes to infastructure added by change

Updated service.yml to cache deps folder for SAM

Updated ci.yml to only trigger on pull requests to master and pushes on master

Added helper script to write a multiline string to a YML file under a specified key

Added helper script to extract and write the proposed changeset to a given file

# Why

Change set comment:
- Enables highlighting of unintended/non-required infrastructure changes in PR without looking at the actions output

Cache deps folder:
- SAM was unable to use cache for lambda functions as the deps folder was not present

Multiline string to YML script:
- The `chuhlomin/render-template@v1.6` action does not support multiline strings, therefore, had to write the string to a file before using that action