### PR TITLE
chore/upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "devDependencies": {
                 "@apify/consts": "^1.3.0",
-                "@aws-sdk/types": "3.226.0",
+                "@aws-sdk/types": "^3.226.0",
                 "@graphql-codegen/cli": "^2.13.12",
                 "@graphql-codegen/typescript": "^2.8.2",
                 "@tsconfig/node18": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "devDependencies": {
         "@apify/consts": "^1.3.0",
-        "@aws-sdk/types": "3.226.0",
+        "@aws-sdk/types": "^3.226.0",
         "@graphql-codegen/cli": "^2.13.12",
         "@graphql-codegen/typescript": "^2.8.2",
         "@tsconfig/node18": "^1.0.1",

--- a/services/crawl/functions/crawl-urls/package-lock.json
+++ b/services/crawl/functions/crawl-urls/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@crawlee/cheerio": "3.1.4",
-                "rxjs": "7.4.0"
+                "rxjs": "7.8.0"
             }
         },
         "node_modules/@apify/consts": {
@@ -1059,17 +1059,12 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-            "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
             "dependencies": {
-                "tslib": "~2.1.0"
+                "tslib": "^2.1.0"
             }
-        },
-        "node_modules/rxjs/node_modules/tslib": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -2018,18 +2013,11 @@
             "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
         },
         "rxjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
-            "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
             "requires": {
-                "tslib": "~2.1.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
-                }
+                "tslib": "^2.1.0"
             }
         },
         "safer-buffer": {

--- a/services/crawl/functions/crawl-urls/package.json
+++ b/services/crawl/functions/crawl-urls/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "dependencies": {
         "@crawlee/cheerio": "3.1.4",
-        "rxjs": "7.4.0"
+        "rxjs": "7.8.0"
     }
 }

--- a/services/crawl/functions/package-lock.json
+++ b/services/crawl/functions/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@ashley-evans/buzzword-object-validator": "1.0.0",
-                "ajv": "8.8.2"
+                "ajv": "8.11.2"
             }
         },
         "node_modules/@ashley-evans/buzzword-object-validator": {
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-            "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -78,9 +78,9 @@
             "requires": {}
         },
         "ajv": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-            "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",

--- a/services/crawl/functions/package.json
+++ b/services/crawl/functions/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "dependencies": {
         "@ashley-evans/buzzword-object-validator": "1.0.0",
-        "ajv": "8.8.2"
+        "ajv": "8.11.2"
     }
 }

--- a/services/crawl/functions/query-crawl/adapters/CrawlStateMachineAdapter.ts
+++ b/services/crawl/functions/query-crawl/adapters/CrawlStateMachineAdapter.ts
@@ -1,7 +1,6 @@
 import {
     DescribeExecutionCommand,
     DescribeExecutionCommandOutput,
-    ExecutionStatus,
     ListExecutionsCommand,
     SFNClient,
 } from "@aws-sdk/client-sfn";
@@ -38,7 +37,7 @@ class CrawlStateMachineAdapter implements CrawlRepositoryPort {
         const command = new ListExecutionsCommand({
             stateMachineArn: this.stateMachineARN,
             maxResults: limit,
-            statusFilter: ExecutionStatus.SUCCEEDED,
+            statusFilter: "SUCCEEDED",
         });
 
         const executions = (await this.client.send(command)).executions;

--- a/services/crawl/functions/query-crawl/package-lock.json
+++ b/services/crawl/functions/query-crawl/package-lock.json
@@ -7,14 +7,15 @@
         "": {
             "name": "buzzword-crawl-query-crawl-lambda",
             "version": "1.0.0",
-            "dependencies": {
-                "@aws-sdk/client-sfn": "3.236.0"
+            "devDependencies": {
+                "@aws-sdk/client-sfn": "^3.241.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
             "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -22,12 +23,14 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -42,12 +45,14 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -57,12 +62,14 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
             "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -70,12 +77,14 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -85,12 +94,14 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -100,15 +111,16 @@
             }
         },
         "node_modules/@aws-sdk/client-sfn": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.236.0.tgz",
-            "integrity": "sha512-1yGEk4sz3EACJxkxch0noRcl0Q832Z4TNYBeUqNJPQTvlDfW2DNST4eaA20ZfnFSkYA/swstQE1XG+cdeW/jmA==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.241.0.tgz",
+            "integrity": "sha512-TN7I7f7KgPQlrUASrfCTPUZAEc62uIPQKAckoVdW6iOAVUrWsTJkkVxq4efHZF/Tso/JMP5pygb9LZKgcG9kqQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -133,7 +145,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -146,9 +158,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -176,7 +189,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -189,9 +202,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -219,7 +233,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -232,14 +246,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -265,7 +280,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -282,6 +297,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -297,6 +313,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -310,6 +327,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -322,14 +340,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -341,15 +360,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -364,6 +384,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -375,14 +396,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             },
@@ -394,6 +416,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -407,6 +430,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -419,6 +443,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -432,6 +457,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -441,6 +467,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -452,6 +479,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -465,6 +493,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -483,6 +512,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -496,6 +526,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -508,6 +539,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -521,6 +553,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -538,6 +571,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -554,6 +588,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -566,6 +601,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -582,6 +618,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -593,6 +630,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -606,6 +644,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -620,6 +659,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -635,6 +675,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -647,6 +688,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -659,6 +701,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -672,6 +715,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -684,6 +728,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
             "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -692,6 +737,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -704,6 +750,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -720,6 +767,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -730,11 +778,12 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -748,6 +797,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -759,6 +809,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -769,6 +820,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -781,6 +833,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -789,6 +842,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -800,6 +854,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -812,6 +867,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -823,6 +879,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -837,6 +894,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -850,9 +908,10 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -865,6 +924,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -876,6 +936,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
             "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -887,6 +948,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -898,6 +960,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -910,6 +973,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -921,6 +985,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -931,6 +996,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -952,6 +1018,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -960,6 +1027,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -971,12 +1039,14 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "node_modules/fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -991,17 +1061,20 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "node_modules/tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -1012,6 +1085,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
             "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1019,7 +1093,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1027,6 +1102,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -1041,7 +1117,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1049,6 +1126,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1058,7 +1136,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1066,6 +1145,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
             "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1073,7 +1153,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1081,6 +1162,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1090,7 +1172,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1098,21 +1181,23 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/client-sfn": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.236.0.tgz",
-            "integrity": "sha512-1yGEk4sz3EACJxkxch0noRcl0Q832Z4TNYBeUqNJPQTvlDfW2DNST4eaA20ZfnFSkYA/swstQE1XG+cdeW/jmA==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.241.0.tgz",
+            "integrity": "sha512-TN7I7f7KgPQlrUASrfCTPUZAEc62uIPQKAckoVdW6iOAVUrWsTJkkVxq4efHZF/Tso/JMP5pygb9LZKgcG9kqQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1137,7 +1222,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1147,9 +1232,10 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1177,7 +1263,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1187,9 +1273,10 @@
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1217,7 +1304,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1227,14 +1314,15 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1260,7 +1348,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1274,6 +1362,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1286,6 +1375,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1296,6 +1386,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1305,14 +1396,15 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1321,15 +1413,16 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1341,6 +1434,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1349,14 +1443,15 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
@@ -1365,6 +1460,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1375,6 +1471,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -1387,6 +1484,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -1397,6 +1495,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1406,6 +1505,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1414,6 +1514,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1424,6 +1525,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1439,6 +1541,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1449,6 +1552,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1458,6 +1562,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1468,6 +1573,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -1482,6 +1588,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1495,6 +1602,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1504,6 +1612,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1517,6 +1626,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1525,6 +1635,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1535,6 +1646,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1546,6 +1658,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1558,6 +1671,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1567,6 +1681,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1576,6 +1691,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -1586,6 +1702,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1594,12 +1711,14 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1609,6 +1728,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1622,6 +1742,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1629,11 +1750,12 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1644,6 +1766,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1652,6 +1775,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1662,6 +1786,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1671,6 +1796,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1679,6 +1805,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1687,6 +1814,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -1696,6 +1824,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1704,6 +1833,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1715,6 +1845,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -1725,9 +1856,10 @@
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1737,6 +1869,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1745,6 +1878,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
             "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1753,6 +1887,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1761,6 +1896,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -1770,6 +1906,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1778,6 +1915,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -1788,6 +1926,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1798,6 +1937,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1806,6 +1946,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1814,12 +1955,14 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -1827,17 +1970,20 @@
         "strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         }
     }
 }

--- a/services/crawl/functions/query-crawl/package.json
+++ b/services/crawl/functions/query-crawl/package.json
@@ -1,7 +1,7 @@
 {
     "name": "buzzword-crawl-query-crawl-lambda",
     "version": "1.0.0",
-    "dependencies": {
-        "@aws-sdk/client-sfn": "3.236.0"
+    "devDependencies": {
+        "@aws-sdk/client-sfn": "^3.241.0"
     }
 }

--- a/services/crawl/functions/recent-crawl/package-lock.json
+++ b/services/crawl/functions/recent-crawl/package-lock.json
@@ -8,20 +8,20 @@
             "name": "buzzword-crawl-recent-crawl-lambda",
             "version": "1.0.0",
             "dependencies": {
-                "dayjs": "1.11.6"
+                "dayjs": "1.11.7"
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-            "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
+            "version": "1.11.7",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
         }
     },
     "dependencies": {
         "dayjs": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-            "integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
+            "version": "1.11.7",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
         }
     }
 }

--- a/services/crawl/functions/recent-crawl/package.json
+++ b/services/crawl/functions/recent-crawl/package.json
@@ -2,6 +2,6 @@
     "name": "buzzword-crawl-recent-crawl-lambda",
     "version": "1.0.0",
     "dependencies": {
-        "dayjs": "1.11.6"
+        "dayjs": "1.11.7"
     }
 }

--- a/services/crawl/libs/content-repository-library/package-lock.json
+++ b/services/crawl/libs/content-repository-library/package-lock.json
@@ -7,14 +7,15 @@
         "": {
             "name": "buzzword-crawl-content-repository-library",
             "version": "1.0.0",
-            "dependencies": {
-                "@aws-sdk/client-s3": "3.236.0"
+            "devDependencies": {
+                "@aws-sdk/client-s3": "^3.241.0"
             }
         },
         "node_modules/@aws-crypto/crc32": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -24,12 +25,14 @@
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/crc32c": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
             "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -39,12 +42,14 @@
         "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/ie11-detection": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -52,12 +57,14 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha1-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
             "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/supports-web-crypto": "^2.0.0",
@@ -70,12 +77,14 @@
         "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -90,12 +99,14 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -105,12 +116,14 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -118,12 +131,14 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -133,12 +148,14 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -151,6 +168,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
             "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -159,22 +177,24 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
             "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-base64": "3.208.0",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.236.0.tgz",
-            "integrity": "sha512-SfTq6M8a1QxMGJVzKaC+pfBzBf//Ywojb6BFhCK7jjtsUEAzvWzaaD6QbRSrZ4sN9+hpLpM7FkgXZ9NOsBX3Tg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
+            "integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha1-browser": "2.0.0",
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/eventstream-serde-browser": "3.226.0",
                 "@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
                 "@aws-sdk/eventstream-serde-node": "3.226.0",
@@ -212,7 +232,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-stream-browser": "3.226.0",
                 "@aws-sdk/util-stream-node": "3.226.0",
@@ -230,9 +250,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -260,7 +281,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -273,9 +294,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -303,7 +325,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -316,14 +338,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -349,7 +372,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -366,6 +389,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -381,6 +405,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -394,6 +419,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -406,14 +432,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -425,15 +452,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -448,6 +476,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -459,14 +488,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             },
@@ -478,6 +508,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -491,6 +522,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
             "integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.226.0",
@@ -502,6 +534,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
             "integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -515,6 +548,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
             "integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -527,6 +561,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
             "integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -540,6 +575,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
             "integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/eventstream-codec": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -553,6 +589,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -565,6 +602,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
             "integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.188.0",
                 "@aws-sdk/chunked-blob-reader-native": "3.208.0",
@@ -576,6 +614,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -589,6 +628,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
             "integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -601,6 +641,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -610,6 +651,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -621,6 +663,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
             "integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -632,6 +675,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
             "integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -647,6 +691,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -660,6 +705,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -678,6 +724,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
             "integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -691,6 +738,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
             "integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-crypto/crc32c": "2.0.0",
@@ -707,6 +755,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -720,6 +769,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
             "integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -732,6 +782,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -744,6 +795,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -757,6 +809,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -774,6 +827,7 @@
             "version": "3.231.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
             "integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -788,6 +842,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -804,6 +859,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -816,6 +872,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -832,6 +889,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
             "integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -844,6 +902,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -855,6 +914,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -868,6 +928,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -882,6 +943,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -897,6 +959,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -909,6 +972,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -921,6 +985,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -934,6 +999,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -946,6 +1012,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
             "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -954,6 +1021,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -966,6 +1034,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -982,6 +1051,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
             "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/signature-v4": "3.226.0",
@@ -1005,6 +1075,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1015,11 +1086,12 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1033,6 +1105,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1044,6 +1117,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1054,6 +1128,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
             "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1065,6 +1140,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1077,6 +1153,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1085,6 +1162,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1096,6 +1174,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -1108,6 +1187,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1119,6 +1199,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1133,6 +1214,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -1146,9 +1228,10 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1161,6 +1244,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1169,20 +1253,22 @@
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-            "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
             "engines": {
-                "node": ">= 12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/util-middleware": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1194,6 +1280,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -1206,6 +1293,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
             "integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1219,6 +1307,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
             "integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1233,6 +1322,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1244,6 +1334,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -1254,6 +1345,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1275,6 +1367,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1283,6 +1376,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1295,6 +1389,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
             "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1308,6 +1403,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
             "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1318,12 +1414,14 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "node_modules/fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -1338,17 +1436,20 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -1359,6 +1460,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1368,7 +1470,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1376,6 +1479,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
             "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1385,14 +1489,16 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
         "@aws-crypto/ie11-detection": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1400,7 +1506,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1408,6 +1515,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
             "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/supports-web-crypto": "^2.0.0",
@@ -1420,7 +1528,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1428,6 +1537,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -1442,7 +1552,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1450,6 +1561,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1459,14 +1571,16 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
         "@aws-crypto/supports-web-crypto": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1474,7 +1588,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1482,6 +1597,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1491,7 +1607,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1499,6 +1616,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1508,6 +1626,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
             "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1516,22 +1635,24 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
             "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-base64": "3.208.0",
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/client-s3": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.236.0.tgz",
-            "integrity": "sha512-SfTq6M8a1QxMGJVzKaC+pfBzBf//Ywojb6BFhCK7jjtsUEAzvWzaaD6QbRSrZ4sN9+hpLpM7FkgXZ9NOsBX3Tg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
+            "integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha1-browser": "2.0.0",
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/eventstream-serde-browser": "3.226.0",
                 "@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
                 "@aws-sdk/eventstream-serde-node": "3.226.0",
@@ -1569,7 +1690,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-stream-browser": "3.226.0",
                 "@aws-sdk/util-stream-node": "3.226.0",
@@ -1584,9 +1705,10 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1614,7 +1736,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1624,9 +1746,10 @@
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1654,7 +1777,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1664,14 +1787,15 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1697,7 +1821,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1711,6 +1835,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1723,6 +1848,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1733,6 +1859,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1742,14 +1869,15 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1758,15 +1886,16 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1778,6 +1907,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1786,14 +1916,15 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
@@ -1802,6 +1933,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1812,6 +1944,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
             "integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1823,6 +1956,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
             "integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1833,6 +1967,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
             "integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1842,6 +1977,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
             "integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1852,6 +1988,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
             "integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/eventstream-codec": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1862,6 +1999,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -1874,6 +2012,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
             "integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/chunked-blob-reader": "3.188.0",
                 "@aws-sdk/chunked-blob-reader-native": "3.208.0",
@@ -1885,6 +2024,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -1895,6 +2035,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
             "integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1904,6 +2045,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1913,6 +2055,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1921,6 +2064,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
             "integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -1932,6 +2076,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
             "integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1944,6 +2089,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1954,6 +2100,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1969,6 +2116,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
             "integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1979,6 +2127,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
             "integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-crypto/crc32c": "2.0.0",
@@ -1992,6 +2141,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2002,6 +2152,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
             "integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2011,6 +2162,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2020,6 +2172,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2030,6 +2183,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -2044,6 +2198,7 @@
             "version": "3.231.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
             "integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2055,6 +2210,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -2068,6 +2224,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2077,6 +2234,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -2090,6 +2248,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
             "integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2099,6 +2258,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2107,6 +2267,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2117,6 +2278,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -2128,6 +2290,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -2140,6 +2303,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2149,6 +2313,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2158,6 +2323,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -2168,6 +2334,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2176,12 +2343,14 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2191,6 +2360,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2204,6 +2374,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
             "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/signature-v4": "3.226.0",
@@ -2216,6 +2387,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2223,11 +2395,12 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2238,6 +2411,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2246,6 +2420,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2256,6 +2431,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
             "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2264,6 +2440,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -2273,6 +2450,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2281,6 +2459,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2289,6 +2468,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -2298,6 +2478,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2306,6 +2487,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2317,6 +2499,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -2327,9 +2510,10 @@
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2339,14 +2523,16 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/util-locate-window": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-            "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2355,6 +2541,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2363,6 +2550,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -2372,6 +2560,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
             "integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2385,6 +2574,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
             "integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2396,6 +2586,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2404,6 +2595,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -2414,6 +2606,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2424,6 +2617,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2432,6 +2626,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -2441,6 +2636,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
             "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2451,6 +2647,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
             "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2458,12 +2655,14 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -2471,17 +2670,20 @@
         "strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         }
     }
 }

--- a/services/crawl/libs/content-repository-library/package.json
+++ b/services/crawl/libs/content-repository-library/package.json
@@ -2,7 +2,7 @@
     "name": "buzzword-crawl-content-repository-library",
     "version": "1.0.0",
     "main": "./index.js",
-    "dependencies": {
-        "@aws-sdk/client-s3": "3.236.0"
+    "devDependencies": {
+        "@aws-sdk/client-s3": "^3.241.0"
     }
 }

--- a/services/crawl/libs/event-client-library/package-lock.json
+++ b/services/crawl/libs/event-client-library/package-lock.json
@@ -7,14 +7,15 @@
         "": {
             "name": "buzzword-crawl-event-client-library",
             "version": "1.0.0",
-            "dependencies": {
-                "@aws-sdk/client-eventbridge": "3.236.0"
+            "devDependencies": {
+                "@aws-sdk/client-eventbridge": "^3.241.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
             "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -22,12 +23,14 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -42,12 +45,14 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -57,12 +62,14 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
             "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -70,12 +77,14 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -85,12 +94,14 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -100,15 +111,16 @@
             }
         },
         "node_modules/@aws-sdk/client-eventbridge": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.236.0.tgz",
-            "integrity": "sha512-AcMXCMTkhfRC1CjO3pKaUxr1H23rPR0KHyYZ8iAmHjtCTO+Y3uVahqTzRvHgfThV+686bONwL+VboWSqZkfFTA==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.241.0.tgz",
+            "integrity": "sha512-1SXxizyaqdnUwXsvdjur1RgOt8zXBCKwz+Qs6YtCMwGlS6vPhZZkXTpP/408HcD2yvoAoonGN6r+QJ+r6uiHDw==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -134,7 +146,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -147,9 +159,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -177,7 +190,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -190,9 +203,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -220,7 +234,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -233,14 +247,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -266,7 +281,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -283,6 +298,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -298,6 +314,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -311,6 +328,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -323,14 +341,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -342,15 +361,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -365,6 +385,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -376,14 +397,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             },
@@ -395,6 +417,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -408,6 +431,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -420,6 +444,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -433,6 +458,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -442,6 +468,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -453,6 +480,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -466,6 +494,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -484,6 +513,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -497,6 +527,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -509,6 +540,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -522,6 +554,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -539,6 +572,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -555,6 +589,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -567,6 +602,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -583,6 +619,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -594,6 +631,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -607,6 +645,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -621,6 +660,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -636,6 +676,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -648,6 +689,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -660,6 +702,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -673,6 +716,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -685,6 +729,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
             "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -693,6 +738,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -705,6 +751,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -721,6 +768,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
             "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/signature-v4": "3.226.0",
@@ -744,6 +792,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -754,11 +803,12 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -772,6 +822,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -783,6 +834,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -793,6 +845,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
             "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -804,6 +857,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -816,6 +870,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -824,6 +879,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -835,6 +891,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -847,6 +904,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -858,6 +916,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -872,6 +931,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -885,9 +945,10 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -900,6 +961,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -911,6 +973,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
             "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -922,6 +985,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -933,6 +997,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -945,6 +1010,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -956,6 +1022,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -966,6 +1033,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -987,6 +1055,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -995,6 +1064,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1006,12 +1076,14 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "node_modules/fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -1026,17 +1098,20 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "node_modules/tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -1047,6 +1122,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
             "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1054,7 +1130,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1062,6 +1139,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -1076,7 +1154,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1084,6 +1163,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1093,7 +1173,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1101,6 +1182,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
             "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1108,7 +1190,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1116,6 +1199,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1125,7 +1209,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1133,21 +1218,23 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/client-eventbridge": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.236.0.tgz",
-            "integrity": "sha512-AcMXCMTkhfRC1CjO3pKaUxr1H23rPR0KHyYZ8iAmHjtCTO+Y3uVahqTzRvHgfThV+686bONwL+VboWSqZkfFTA==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-eventbridge/-/client-eventbridge-3.241.0.tgz",
+            "integrity": "sha512-1SXxizyaqdnUwXsvdjur1RgOt8zXBCKwz+Qs6YtCMwGlS6vPhZZkXTpP/408HcD2yvoAoonGN6r+QJ+r6uiHDw==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1173,7 +1260,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1183,9 +1270,10 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1213,7 +1301,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1223,9 +1311,10 @@
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1253,7 +1342,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1263,14 +1352,15 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1296,7 +1386,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1310,6 +1400,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1322,6 +1413,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1332,6 +1424,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1341,14 +1434,15 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1357,15 +1451,16 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1377,6 +1472,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1385,14 +1481,15 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
@@ -1401,6 +1498,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1411,6 +1509,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -1423,6 +1522,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -1433,6 +1533,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1442,6 +1543,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1450,6 +1552,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1460,6 +1563,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1475,6 +1579,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1485,6 +1590,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1494,6 +1600,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1504,6 +1611,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -1518,6 +1626,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1531,6 +1640,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1540,6 +1650,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1553,6 +1664,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1561,6 +1673,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1571,6 +1684,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1582,6 +1696,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1594,6 +1709,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1603,6 +1719,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1612,6 +1729,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -1622,6 +1740,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1630,12 +1749,14 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1645,6 +1766,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1658,6 +1780,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
             "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/signature-v4": "3.226.0",
@@ -1670,6 +1793,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1677,11 +1801,12 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1692,6 +1817,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1700,6 +1826,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1710,6 +1837,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
             "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1718,6 +1846,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1727,6 +1856,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1735,6 +1865,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1743,6 +1874,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -1752,6 +1884,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1760,6 +1893,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1771,6 +1905,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -1781,9 +1916,10 @@
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1793,6 +1929,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1801,6 +1938,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
             "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1809,6 +1947,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1817,6 +1956,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -1826,6 +1966,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1834,6 +1975,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -1844,6 +1986,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1854,6 +1997,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1862,6 +2006,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1870,12 +2015,14 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -1883,17 +2030,20 @@
         "strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         }
     }
 }

--- a/services/crawl/libs/event-client-library/package.json
+++ b/services/crawl/libs/event-client-library/package.json
@@ -2,7 +2,7 @@
     "name": "buzzword-crawl-event-client-library",
     "version": "1.0.0",
     "main": "./index.js",
-    "dependencies": {
-        "@aws-sdk/client-eventbridge": "3.236.0"
+    "devDependencies": {
+        "@aws-sdk/client-eventbridge": "^3.241.0"
     }
 }

--- a/services/crawl/libs/urls-repository-library/package-lock.json
+++ b/services/crawl/libs/urls-repository-library/package-lock.json
@@ -8,7 +8,7 @@
             "name": "buzzword-crawl-urls-repository-library",
             "version": "1.0.0",
             "dependencies": {
-                "dynamoose": "3.0.0"
+                "dynamoose": "3.1.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {
@@ -923,9 +923,9 @@
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/dynamoose": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.0.0.tgz",
-            "integrity": "sha512-j9KWtuumIBzoLJBNLuONe7I2Xp0QDDdaYutjG7bGLgOjtNKZY2z2wihlEK3vfbAhvt+ckAFwvXP6nQvcgur17Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.1.0.tgz",
+            "integrity": "sha512-YR1AeTp6/aOyM5dZIUAKpgmwn7YxlJNSz00zminFSzlpfxkq/6n9qa0Ws79XwdM0+Q4AVRvwhWtlMI+H2Zi59Q==",
             "funding": [
                 {
                     "type": "github-sponsors",
@@ -939,14 +939,14 @@
             "dependencies": {
                 "@aws-sdk/client-dynamodb": "^3.142.0",
                 "@aws-sdk/util-dynamodb": "^3.142.0",
-                "dynamoose-utils": "^3.0.0",
+                "dynamoose-utils": "^3.1.0",
                 "js-object-utilities": "^2.1.0"
             }
         },
         "node_modules/dynamoose-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0.tgz",
-            "integrity": "sha512-Vq3mXWlnRDMkJe0mSRVlckn2EtzEo/y2LUyvErQdOncDZm2Oe5MS/euHjNAxZuPt2qZ/gzSyTwK6P3K1gqcXog==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+            "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
             "funding": [
                 {
                     "type": "github-sponsors",
@@ -1775,20 +1775,20 @@
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "dynamoose": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.0.0.tgz",
-            "integrity": "sha512-j9KWtuumIBzoLJBNLuONe7I2Xp0QDDdaYutjG7bGLgOjtNKZY2z2wihlEK3vfbAhvt+ckAFwvXP6nQvcgur17Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.1.0.tgz",
+            "integrity": "sha512-YR1AeTp6/aOyM5dZIUAKpgmwn7YxlJNSz00zminFSzlpfxkq/6n9qa0Ws79XwdM0+Q4AVRvwhWtlMI+H2Zi59Q==",
             "requires": {
                 "@aws-sdk/client-dynamodb": "^3.142.0",
                 "@aws-sdk/util-dynamodb": "^3.142.0",
-                "dynamoose-utils": "^3.0.0",
+                "dynamoose-utils": "^3.1.0",
                 "js-object-utilities": "^2.1.0"
             }
         },
         "dynamoose-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0.tgz",
-            "integrity": "sha512-Vq3mXWlnRDMkJe0mSRVlckn2EtzEo/y2LUyvErQdOncDZm2Oe5MS/euHjNAxZuPt2qZ/gzSyTwK6P3K1gqcXog==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+            "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
             "requires": {
                 "js-object-utilities": "^2.1.0"
             }

--- a/services/crawl/libs/urls-repository-library/package.json
+++ b/services/crawl/libs/urls-repository-library/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "main": "./index.js",
     "dependencies": {
-        "dynamoose": "3.0.0"
+        "dynamoose": "3.1.0"
     }
 }

--- a/services/keyphrase/functions/package-lock.json
+++ b/services/keyphrase/functions/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "dependencies": {
                 "@ashley-evans/buzzword-object-validator": "1.0.0",
-                "ajv": "8.8.2"
+                "ajv": "8.11.2"
             }
         },
         "node_modules/@ashley-evans/buzzword-object-validator": {
@@ -21,9 +21,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-            "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -78,9 +78,9 @@
             "requires": {}
         },
         "ajv": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-            "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",

--- a/services/keyphrase/functions/package.json
+++ b/services/keyphrase/functions/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "dependencies": {
         "@ashley-evans/buzzword-object-validator": "1.0.0",
-        "ajv": "8.8.2"
+        "ajv": "8.11.2"
     }
 }

--- a/services/keyphrase/libs/active-connections-repository-library/package-lock.json
+++ b/services/keyphrase/libs/active-connections-repository-library/package-lock.json
@@ -8,7 +8,7 @@
             "name": "buzzword-keyphrase-active-connections-repository-library",
             "version": "1.0.0",
             "dependencies": {
-                "dynamoose": "3.0.0"
+                "dynamoose": "3.1.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {
@@ -923,9 +923,9 @@
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/dynamoose": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.0.0.tgz",
-            "integrity": "sha512-j9KWtuumIBzoLJBNLuONe7I2Xp0QDDdaYutjG7bGLgOjtNKZY2z2wihlEK3vfbAhvt+ckAFwvXP6nQvcgur17Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.1.0.tgz",
+            "integrity": "sha512-YR1AeTp6/aOyM5dZIUAKpgmwn7YxlJNSz00zminFSzlpfxkq/6n9qa0Ws79XwdM0+Q4AVRvwhWtlMI+H2Zi59Q==",
             "funding": [
                 {
                     "type": "github-sponsors",
@@ -939,14 +939,14 @@
             "dependencies": {
                 "@aws-sdk/client-dynamodb": "^3.142.0",
                 "@aws-sdk/util-dynamodb": "^3.142.0",
-                "dynamoose-utils": "^3.0.0",
+                "dynamoose-utils": "^3.1.0",
                 "js-object-utilities": "^2.1.0"
             }
         },
         "node_modules/dynamoose-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0.tgz",
-            "integrity": "sha512-Vq3mXWlnRDMkJe0mSRVlckn2EtzEo/y2LUyvErQdOncDZm2Oe5MS/euHjNAxZuPt2qZ/gzSyTwK6P3K1gqcXog==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+            "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
             "funding": [
                 {
                     "type": "github-sponsors",
@@ -1775,20 +1775,20 @@
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "dynamoose": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.0.0.tgz",
-            "integrity": "sha512-j9KWtuumIBzoLJBNLuONe7I2Xp0QDDdaYutjG7bGLgOjtNKZY2z2wihlEK3vfbAhvt+ckAFwvXP6nQvcgur17Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.1.0.tgz",
+            "integrity": "sha512-YR1AeTp6/aOyM5dZIUAKpgmwn7YxlJNSz00zminFSzlpfxkq/6n9qa0Ws79XwdM0+Q4AVRvwhWtlMI+H2Zi59Q==",
             "requires": {
                 "@aws-sdk/client-dynamodb": "^3.142.0",
                 "@aws-sdk/util-dynamodb": "^3.142.0",
-                "dynamoose-utils": "^3.0.0",
+                "dynamoose-utils": "^3.1.0",
                 "js-object-utilities": "^2.1.0"
             }
         },
         "dynamoose-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0.tgz",
-            "integrity": "sha512-Vq3mXWlnRDMkJe0mSRVlckn2EtzEo/y2LUyvErQdOncDZm2Oe5MS/euHjNAxZuPt2qZ/gzSyTwK6P3K1gqcXog==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+            "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
             "requires": {
                 "js-object-utilities": "^2.1.0"
             }

--- a/services/keyphrase/libs/active-connections-repository-library/package.json
+++ b/services/keyphrase/libs/active-connections-repository-library/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "main": "./index.js",
     "dependencies": {
-        "dynamoose": "3.0.0"
+        "dynamoose": "3.1.0"
     }
 }

--- a/services/keyphrase/libs/keyphrase-repository-library/package-lock.json
+++ b/services/keyphrase/libs/keyphrase-repository-library/package-lock.json
@@ -8,7 +8,7 @@
             "name": "buzzword-keyphrase-keyphrase-repository-library",
             "version": "1.0.0",
             "dependencies": {
-                "dynamoose": "3.0.0"
+                "dynamoose": "3.1.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {
@@ -923,9 +923,9 @@
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/dynamoose": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.0.0.tgz",
-            "integrity": "sha512-j9KWtuumIBzoLJBNLuONe7I2Xp0QDDdaYutjG7bGLgOjtNKZY2z2wihlEK3vfbAhvt+ckAFwvXP6nQvcgur17Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.1.0.tgz",
+            "integrity": "sha512-YR1AeTp6/aOyM5dZIUAKpgmwn7YxlJNSz00zminFSzlpfxkq/6n9qa0Ws79XwdM0+Q4AVRvwhWtlMI+H2Zi59Q==",
             "funding": [
                 {
                     "type": "github-sponsors",
@@ -939,14 +939,14 @@
             "dependencies": {
                 "@aws-sdk/client-dynamodb": "^3.142.0",
                 "@aws-sdk/util-dynamodb": "^3.142.0",
-                "dynamoose-utils": "^3.0.0",
+                "dynamoose-utils": "^3.1.0",
                 "js-object-utilities": "^2.1.0"
             }
         },
         "node_modules/dynamoose-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0.tgz",
-            "integrity": "sha512-Vq3mXWlnRDMkJe0mSRVlckn2EtzEo/y2LUyvErQdOncDZm2Oe5MS/euHjNAxZuPt2qZ/gzSyTwK6P3K1gqcXog==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+            "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
             "funding": [
                 {
                     "type": "github-sponsors",
@@ -1775,20 +1775,20 @@
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "dynamoose": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.0.0.tgz",
-            "integrity": "sha512-j9KWtuumIBzoLJBNLuONe7I2Xp0QDDdaYutjG7bGLgOjtNKZY2z2wihlEK3vfbAhvt+ckAFwvXP6nQvcgur17Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose/-/dynamoose-3.1.0.tgz",
+            "integrity": "sha512-YR1AeTp6/aOyM5dZIUAKpgmwn7YxlJNSz00zminFSzlpfxkq/6n9qa0Ws79XwdM0+Q4AVRvwhWtlMI+H2Zi59Q==",
             "requires": {
                 "@aws-sdk/client-dynamodb": "^3.142.0",
                 "@aws-sdk/util-dynamodb": "^3.142.0",
-                "dynamoose-utils": "^3.0.0",
+                "dynamoose-utils": "^3.1.0",
                 "js-object-utilities": "^2.1.0"
             }
         },
         "dynamoose-utils": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.0.0.tgz",
-            "integrity": "sha512-Vq3mXWlnRDMkJe0mSRVlckn2EtzEo/y2LUyvErQdOncDZm2Oe5MS/euHjNAxZuPt2qZ/gzSyTwK6P3K1gqcXog==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/dynamoose-utils/-/dynamoose-utils-3.1.0.tgz",
+            "integrity": "sha512-HeSR4H9HvhQM2zb+4LuQlfQMHYCSn9aSsAyDArUlqfLn3cDCfrYN/HBMVTv8pNkqOakAB7MlYOW7ubDThbsvKQ==",
             "requires": {
                 "js-object-utilities": "^2.1.0"
             }

--- a/services/keyphrase/libs/keyphrase-repository-library/package.json
+++ b/services/keyphrase/libs/keyphrase-repository-library/package.json
@@ -3,6 +3,6 @@
     "version": "1.0.0",
     "main": "./index.js",
     "dependencies": {
-        "dynamoose": "3.0.0"
+        "dynamoose": "3.1.0"
     }
 }

--- a/services/keyphrase/libs/text-repository-library/package-lock.json
+++ b/services/keyphrase/libs/text-repository-library/package-lock.json
@@ -7,14 +7,15 @@
         "": {
             "name": "buzzword-keyphrase-text-repository-library",
             "version": "1.0.0",
-            "dependencies": {
-                "@aws-sdk/client-s3": "3.236.0"
+            "devDependencies": {
+                "@aws-sdk/client-s3": "^3.241.0"
             }
         },
         "node_modules/@aws-crypto/crc32": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -24,12 +25,14 @@
         "node_modules/@aws-crypto/crc32/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/crc32c": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
             "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -39,12 +42,14 @@
         "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/ie11-detection": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -52,12 +57,14 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha1-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
             "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/supports-web-crypto": "^2.0.0",
@@ -70,12 +77,14 @@
         "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -90,12 +99,14 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -105,12 +116,14 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -118,12 +131,14 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -133,12 +148,14 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -151,6 +168,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
             "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -159,22 +177,24 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
             "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-base64": "3.208.0",
                 "tslib": "^2.3.1"
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.236.0.tgz",
-            "integrity": "sha512-SfTq6M8a1QxMGJVzKaC+pfBzBf//Ywojb6BFhCK7jjtsUEAzvWzaaD6QbRSrZ4sN9+hpLpM7FkgXZ9NOsBX3Tg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
+            "integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha1-browser": "2.0.0",
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/eventstream-serde-browser": "3.226.0",
                 "@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
                 "@aws-sdk/eventstream-serde-node": "3.226.0",
@@ -212,7 +232,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-stream-browser": "3.226.0",
                 "@aws-sdk/util-stream-node": "3.226.0",
@@ -230,9 +250,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -260,7 +281,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -273,9 +294,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -303,7 +325,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -316,14 +338,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -349,7 +372,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -366,6 +389,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -381,6 +405,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -394,6 +419,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -406,14 +432,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -425,15 +452,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -448,6 +476,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -459,14 +488,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             },
@@ -478,6 +508,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -491,6 +522,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
             "integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.226.0",
@@ -502,6 +534,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
             "integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -515,6 +548,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
             "integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -527,6 +561,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
             "integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -540,6 +575,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
             "integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/eventstream-codec": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -553,6 +589,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -565,6 +602,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
             "integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/chunked-blob-reader": "3.188.0",
                 "@aws-sdk/chunked-blob-reader-native": "3.208.0",
@@ -576,6 +614,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -589,6 +628,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
             "integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -601,6 +641,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -610,6 +651,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -621,6 +663,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
             "integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -632,6 +675,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
             "integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -647,6 +691,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -660,6 +705,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -678,6 +724,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
             "integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -691,6 +738,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
             "integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-crypto/crc32c": "2.0.0",
@@ -707,6 +755,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -720,6 +769,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
             "integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -732,6 +782,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -744,6 +795,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -757,6 +809,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -774,6 +827,7 @@
             "version": "3.231.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
             "integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -788,6 +842,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -804,6 +859,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -816,6 +872,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -832,6 +889,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
             "integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -844,6 +902,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -855,6 +914,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -868,6 +928,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -882,6 +943,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -897,6 +959,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -909,6 +972,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -921,6 +985,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -934,6 +999,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -946,6 +1012,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
             "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -954,6 +1021,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -966,6 +1034,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -982,6 +1051,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
             "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/signature-v4": "3.226.0",
@@ -1005,6 +1075,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1015,11 +1086,12 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1033,6 +1105,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1044,6 +1117,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1054,6 +1128,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
             "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1065,6 +1140,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1077,6 +1153,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1085,6 +1162,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1096,6 +1174,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -1108,6 +1187,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1119,6 +1199,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1133,6 +1214,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -1146,9 +1228,10 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1161,6 +1244,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1169,20 +1253,22 @@
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-            "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
             "engines": {
-                "node": ">= 12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@aws-sdk/util-middleware": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1194,6 +1280,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -1206,6 +1293,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
             "integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1219,6 +1307,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
             "integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1233,6 +1322,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1244,6 +1334,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -1254,6 +1345,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1275,6 +1367,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -1283,6 +1376,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1295,6 +1389,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
             "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1308,6 +1403,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
             "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -1318,12 +1414,14 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "node_modules/fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -1338,17 +1436,20 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -1359,6 +1460,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
             "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1368,7 +1470,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1376,6 +1479,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
             "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1385,14 +1489,16 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
         "@aws-crypto/ie11-detection": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
-            "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1400,7 +1506,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1408,6 +1515,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
             "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/supports-web-crypto": "^2.0.0",
@@ -1420,7 +1528,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1428,6 +1537,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -1442,7 +1552,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1450,6 +1561,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1459,14 +1571,16 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
         "@aws-crypto/supports-web-crypto": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.0.tgz",
-            "integrity": "sha512-Ge7WQ3E0OC7FHYprsZV3h0QIcpdyJLvIeg+uTuHqRYm8D6qCFJoiC+edSzSyFiHtZf+NOQDJ1q46qxjtzIY2nA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1474,7 +1588,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1482,6 +1597,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1491,7 +1607,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1499,6 +1616,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1508,6 +1626,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
             "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1516,22 +1635,24 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
             "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-base64": "3.208.0",
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/client-s3": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.236.0.tgz",
-            "integrity": "sha512-SfTq6M8a1QxMGJVzKaC+pfBzBf//Ywojb6BFhCK7jjtsUEAzvWzaaD6QbRSrZ4sN9+hpLpM7FkgXZ9NOsBX3Tg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.241.0.tgz",
+            "integrity": "sha512-GxkiX4f+FUW2Lr3PySc1wuYlfU8QV2nx6KlBY8L8yf2txtajEL0/hhfo5Pbo4Uw1ZZlTv4iPHUOiTrm2R9Rhyg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha1-browser": "2.0.0",
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/eventstream-serde-browser": "3.226.0",
                 "@aws-sdk/eventstream-serde-config-resolver": "3.226.0",
                 "@aws-sdk/eventstream-serde-node": "3.226.0",
@@ -1569,7 +1690,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-stream-browser": "3.226.0",
                 "@aws-sdk/util-stream-node": "3.226.0",
@@ -1584,9 +1705,10 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1614,7 +1736,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1624,9 +1746,10 @@
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1654,7 +1777,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1664,14 +1787,15 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1697,7 +1821,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1711,6 +1835,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1723,6 +1848,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1733,6 +1859,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1742,14 +1869,15 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1758,15 +1886,16 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1778,6 +1907,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1786,14 +1916,15 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
@@ -1802,6 +1933,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1812,6 +1944,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.226.0.tgz",
             "integrity": "sha512-6uPtR8vSwz3fqoZk9hrb6qBYdp3PJ22+JxV5Wimdesvow4kJXSgDQXIxEkxbv6SxB9tNRB4uJHD84RetHEi15Q==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1823,6 +1956,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.226.0.tgz",
             "integrity": "sha512-otYC5aZE9eJUqAlKpy8w0rPDQ1eKGvZPtgxWXmFYSO2lDVGfI1nBBNmdZ4MdHqNuQ7ucsKMQYF8BFJ65K2tYPA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1833,6 +1967,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.226.0.tgz",
             "integrity": "sha512-A56Gypg+lyEfA5cna+EUH9XTrj0SvRG1gwNW7lrUzviN36SeA/LFTUIOEjxVML3Lowy+EPAcrSZ67h6aepoAig==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1842,6 +1977,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.226.0.tgz",
             "integrity": "sha512-KWLnKkKDzI9RNkiK6OiSYpG/XjZfue6Bsp/vRG+H5z3fbXdHv4X2+iW+Efu2Kvn7jsUyUv82TCl57DyJ/HKYhQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/eventstream-serde-universal": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1852,6 +1988,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.226.0.tgz",
             "integrity": "sha512-Q8viYM1Sv90/yIUqyWNeG1GEvyVlAI3GIrInQcCMC+xT59jS+IKGy2y7ojCvSWXnhf5/HMXKcmG092QsqeKy0Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/eventstream-codec": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1862,6 +1999,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -1874,6 +2012,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.226.0.tgz",
             "integrity": "sha512-5DCvWE6L4xGoViEHyjcPFuUe1G2EtNx8TqswWaoaKgyasP/yuRm4H99Ra7rqIrjCcSTAGD9NVsUQvVVw1bGt9w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/chunked-blob-reader": "3.188.0",
                 "@aws-sdk/chunked-blob-reader-native": "3.208.0",
@@ -1885,6 +2024,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -1895,6 +2035,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.226.0.tgz",
             "integrity": "sha512-cgNTGlF8SdHaQXtjEmuLXz2U8SLM2JDKtIVPku/lHTMsUsEn+fuv2C+h1f/hvd4aNw5t1zggym7sO1/h/rv56Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1904,6 +2045,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1913,6 +2055,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1921,6 +2064,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.226.0.tgz",
             "integrity": "sha512-ENigJRNudqyh6xsch166SZ4gggHd3XzZJ8gkCU4CWPne04HcR3BkWSO774IuWooCHt8zkaEHKecPurRz6qR+Vw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-utf8-browser": "3.188.0",
@@ -1932,6 +2076,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.226.0.tgz",
             "integrity": "sha512-A1Vq5W2X7jgTfjqcKPmjoHohF0poP+9fxwL97fQMvzcwmjhtoCV3bLEpo6CGYx0pKPiSlRJXZkRwRPj2hDHDmA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1944,6 +2089,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1954,6 +2100,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1969,6 +2116,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.226.0.tgz",
             "integrity": "sha512-YxvQKTV/eA9P8AgW0hXOgj5Qa+TSnNFfyOkfeP089aP3f6p92b1cESf33TEOKsddive2mHT5LRCN6MuPcgWWrA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1979,6 +2127,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.226.0.tgz",
             "integrity": "sha512-8A9Ot9A7794UP5tMGl2MnfTW/UM/jYy1wRWF9YkR/hPIcPb7OmE0hmlwIQGzb/7grxpYw66ETKf0WeH/41YfeQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/crc32": "2.0.0",
                 "@aws-crypto/crc32c": "2.0.0",
@@ -1992,6 +2141,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2002,6 +2152,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.226.0.tgz",
             "integrity": "sha512-qHiYaBYPc2R37KxG2uqsUUwh4usrQMHfGkrpTUnx5d4rGzM3mC+muPsTpSHnAL63K2/yJOHQJFjss3GGwV4SSA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2011,6 +2162,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2020,6 +2172,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2030,6 +2183,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -2044,6 +2198,7 @@
             "version": "3.231.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.231.0.tgz",
             "integrity": "sha512-UGaSvevd2TanfKgStF46dDSHkh4bxOr1gdUkyHm9i+1pF5lx4KdbnBZv/5SKnn7XifhHRXrs1M3lTzemXREhTA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2055,6 +2210,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -2068,6 +2224,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2077,6 +2234,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -2090,6 +2248,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.226.0.tgz",
             "integrity": "sha512-DR97oWoLHiMdaUP/wu99HtzG7/ijvCrjZGDH37WBO1rxFtEti6L7T09wgHzwxMN8gtL8FJA7dU8IrffGSC9VmA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2099,6 +2258,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2107,6 +2267,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2117,6 +2278,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -2128,6 +2290,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -2140,6 +2303,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2149,6 +2313,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2158,6 +2323,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -2168,6 +2334,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2176,12 +2343,14 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2191,6 +2360,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2204,6 +2374,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.226.0.tgz",
             "integrity": "sha512-QHxNuf9ynK208v7Y3imdsa3Cz8ynYV7ZOf3sBJdItuEtHN6uy/KxaOrtvpF8I5Hyn48Hc8z5miTSMujFKT7GEw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/signature-v4": "3.226.0",
@@ -2216,6 +2387,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2223,11 +2395,12 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2238,6 +2411,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2246,6 +2420,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2256,6 +2431,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
             "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2264,6 +2440,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -2273,6 +2450,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2281,6 +2459,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2289,6 +2468,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -2298,6 +2478,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2306,6 +2487,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2317,6 +2499,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -2327,9 +2510,10 @@
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -2339,14 +2523,16 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/util-locate-window": {
-            "version": "3.55.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.55.0.tgz",
-            "integrity": "sha512-0sPmK2JaJE2BbTcnvybzob/VrFKCXKfN4CUKcvn0yGg/me7Bz+vtzQRB3Xp+YSx+7OtWxzv63wsvHoAnXvgxgg==",
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2355,6 +2541,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2363,6 +2550,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -2372,6 +2560,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.226.0.tgz",
             "integrity": "sha512-ZvjlA1ySaLd0DqUWTKmL7LsxfPhroAONpzsinaHmw9aZVL40s2cADU9eWgBdHTuAOeFklL7NP0cc6UiTFHKe8g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2385,6 +2574,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.226.0.tgz",
             "integrity": "sha512-HADXiIgDGoXcCLSKuPnjCLENf0iC0lzqqnymZu9H2FoACZhJB7DvJ9LnP51Pvw9lfCu+yvLzbMqSPdbXtMbRWg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-http-handler": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2396,6 +2586,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2404,6 +2595,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -2414,6 +2606,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2424,6 +2617,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2432,6 +2626,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -2441,6 +2636,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.226.0.tgz",
             "integrity": "sha512-qYQMRxnu5k8qQihJXoIWMkBOj0+XkHHj/drLdbRnwL6ni6NcG8++cs9M3DSjIcxmxgF/7SLpDjn1H3sC7cYo4g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -2451,6 +2647,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
             "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -2458,12 +2655,14 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -2471,17 +2670,20 @@
         "strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         }
     }
 }

--- a/services/keyphrase/libs/text-repository-library/package.json
+++ b/services/keyphrase/libs/text-repository-library/package.json
@@ -2,7 +2,7 @@
     "name": "buzzword-keyphrase-text-repository-library",
     "version": "1.0.0",
     "main": "./index.js",
-    "dependencies": {
-        "@aws-sdk/client-s3": "3.236.0"
+    "devDependencies": {
+        "@aws-sdk/client-s3": "^3.241.0"
     }
 }

--- a/services/keyphrase/libs/web-socket-client-library/package-lock.json
+++ b/services/keyphrase/libs/web-socket-client-library/package-lock.json
@@ -7,14 +7,15 @@
         "": {
             "name": "buzzword-keyphrase-web-socket-client-library",
             "version": "1.0.0",
-            "dependencies": {
-                "@aws-sdk/client-apigatewaymanagementapi": "3.236.0"
+            "devDependencies": {
+                "@aws-sdk/client-apigatewaymanagementapi": "^3.241.0"
             }
         },
         "node_modules/@aws-crypto/ie11-detection": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
             "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -22,12 +23,14 @@
         "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -42,12 +45,14 @@
         "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -57,12 +62,14 @@
         "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
             "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^1.11.1"
             }
@@ -70,12 +77,14 @@
         "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-crypto/util": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -85,12 +94,14 @@
         "node_modules/@aws-crypto/util/node_modules/tslib": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "dev": true
         },
         "node_modules/@aws-sdk/abort-controller": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -100,15 +111,16 @@
             }
         },
         "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.236.0.tgz",
-            "integrity": "sha512-EehxmB+E6iOkL3+AJb/e5A2IY1EZ9r9EbP24CTfR0y78c3HB4nMAwtf66GtDUIVXWCehI7++0437S/uo7sp6qw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.241.0.tgz",
+            "integrity": "sha512-uaYQeSk+sKeWrNuP3R5I76EcvZTDfdB6RX/o0BErq+MNveRbA5LGHJWw6XmqM4tp7fNGe8uxddjoAyhqC096hQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -133,7 +145,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -146,9 +158,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -176,7 +189,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -189,9 +202,10 @@
             }
         },
         "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -219,7 +233,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -232,14 +246,15 @@
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "dependencies": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -265,7 +280,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -282,6 +297,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -297,6 +313,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -310,6 +327,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -322,14 +340,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -341,15 +360,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -364,6 +384,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -375,14 +396,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             },
@@ -394,6 +416,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -407,6 +430,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -419,6 +443,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -432,6 +457,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -441,6 +467,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -452,6 +479,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -465,6 +493,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -483,6 +512,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -496,6 +526,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -508,6 +539,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -521,6 +553,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -538,6 +571,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -554,6 +588,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -566,6 +601,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -582,6 +618,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -593,6 +630,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -606,6 +644,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -620,6 +659,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -635,6 +675,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -647,6 +688,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -659,6 +701,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -672,6 +715,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -684,6 +728,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
             "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true,
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -692,6 +737,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -704,6 +750,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -720,6 +767,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -730,11 +778,12 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -748,6 +797,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -759,6 +809,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -769,6 +820,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -781,6 +833,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -789,6 +842,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -800,6 +854,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -812,6 +867,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -823,6 +879,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -837,6 +894,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -850,9 +908,10 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -865,6 +924,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -876,6 +936,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
             "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -887,6 +948,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -898,6 +960,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -910,6 +973,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             },
@@ -921,6 +985,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -931,6 +996,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -952,6 +1018,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "dependencies": {
                 "tslib": "^2.3.1"
             }
@@ -960,6 +1027,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "dependencies": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -971,12 +1039,14 @@
         "node_modules/bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "node_modules/fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "dependencies": {
                 "strnum": "^1.0.5"
             },
@@ -991,17 +1061,20 @@
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "node_modules/tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -1012,6 +1085,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
             "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1019,7 +1093,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1027,6 +1102,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
             "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/ie11-detection": "^2.0.0",
                 "@aws-crypto/sha256-js": "^2.0.0",
@@ -1041,7 +1117,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1049,6 +1126,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
             "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/util": "^2.0.0",
                 "@aws-sdk/types": "^3.1.0",
@@ -1058,7 +1136,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1066,6 +1145,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
             "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.11.1"
             },
@@ -1073,7 +1153,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1081,6 +1162,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
             "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "^3.110.0",
                 "@aws-sdk/util-utf8-browser": "^3.0.0",
@@ -1090,7 +1172,8 @@
                 "tslib": {
                     "version": "1.14.1",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+                    "dev": true
                 }
             }
         },
@@ -1098,21 +1181,23 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.226.0.tgz",
             "integrity": "sha512-cJVzr1xxPBd08voknXvR0RLgtZKGKt6WyDpH/BaPCu3rfSqWCDZKzwqe940eqosjmKrxC6pUZNKASIqHOQ8xxQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
         },
         "@aws-sdk/client-apigatewaymanagementapi": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.236.0.tgz",
-            "integrity": "sha512-EehxmB+E6iOkL3+AJb/e5A2IY1EZ9r9EbP24CTfR0y78c3HB4nMAwtf66GtDUIVXWCehI7++0437S/uo7sp6qw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.241.0.tgz",
+            "integrity": "sha512-uaYQeSk+sKeWrNuP3R5I76EcvZTDfdB6RX/o0BErq+MNveRbA5LGHJWw6XmqM4tp7fNGe8uxddjoAyhqC096hQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.236.0",
+                "@aws-sdk/client-sts": "3.241.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1137,7 +1222,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1147,9 +1232,10 @@
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.236.0.tgz",
-            "integrity": "sha512-2E/XHiVSRI+L2SlVscmV/+z4A2iWF6BTUjVBFBGMmsailvGDV6XKPFocTBsHI64G25/SYkhMdELvjn5jHLKBGQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.241.0.tgz",
+            "integrity": "sha512-Jm4HR+RYAqKMEYZvvWaq0NYUKKonyInOeubObXH4BLXZpmUBSdYCSjjLdNJY3jkQoxbDVPVMIurVNh5zT5SMRw==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1177,7 +1263,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1187,9 +1273,10 @@
             }
         },
         "@aws-sdk/client-sso-oidc": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.236.0.tgz",
-            "integrity": "sha512-9TuigSXGafVto+GjKsVkhNLlnSgNWzRL5/ClZ5lY3dWrcDEJGZjFwwRB3ICerFQJBdDfsYwjNjJPhYEHzdyBfQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.241.0.tgz",
+            "integrity": "sha512-/Ml2QBGpGfUEeBrPzBZhSTBkHuXFD2EAZEIHGCBH4tKaURDI6/FoGI8P1Rl4BzoFt+II/Cr91Eox6YT9EwChsQ==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
@@ -1217,7 +1304,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1227,14 +1314,15 @@
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.236.0.tgz",
-            "integrity": "sha512-ruEALU0oPwsA8xZ/HBCoUO9rsyhPyalj20GMGpzVaNcf1dr1jMTThDQvQvvjAHjY3W56mI7ApxjK+D+gok55aw==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.241.0.tgz",
+            "integrity": "sha512-vmlG8cJzRf8skCtTJbA2wBvD2c3NQ5gZryzJvTKDS06KzBzcEpnjlLseuTekcnOiRNekbFUX5hRu5Zj3N2ReLg==",
+            "dev": true,
             "requires": {
                 "@aws-crypto/sha256-browser": "2.0.0",
                 "@aws-crypto/sha256-js": "2.0.0",
                 "@aws-sdk/config-resolver": "3.234.0",
-                "@aws-sdk/credential-provider-node": "3.236.0",
+                "@aws-sdk/credential-provider-node": "3.241.0",
                 "@aws-sdk/fetch-http-handler": "3.226.0",
                 "@aws-sdk/hash-node": "3.226.0",
                 "@aws-sdk/invalid-dependency": "3.226.0",
@@ -1260,7 +1348,7 @@
                 "@aws-sdk/util-body-length-node": "3.208.0",
                 "@aws-sdk/util-defaults-mode-browser": "3.234.0",
                 "@aws-sdk/util-defaults-mode-node": "3.234.0",
-                "@aws-sdk/util-endpoints": "3.226.0",
+                "@aws-sdk/util-endpoints": "3.241.0",
                 "@aws-sdk/util-retry": "3.229.0",
                 "@aws-sdk/util-user-agent-browser": "3.226.0",
                 "@aws-sdk/util-user-agent-node": "3.226.0",
@@ -1274,6 +1362,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.234.0.tgz",
             "integrity": "sha512-uZxy4wzllfvgCQxVc+Iqhde0NGAnfmV2hWR6ejadJaAFTuYNvQiRg9IqJy3pkyDPqXySiJ8Bom5PoJfgn55J/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/signature-v4": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1286,6 +1375,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.226.0.tgz",
             "integrity": "sha512-sd8uK1ojbXxaZXlthzw/VXZwCPUtU3PjObOfr3Evj7MPIM2IH8h29foOlggx939MdLQGboJf9gKvLlvKDWtJRA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1296,6 +1386,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.226.0.tgz",
             "integrity": "sha512-//z/COQm2AjYFI1Lb0wKHTQSrvLFTyuKLFQGPJsKS7DPoxGOCKB7hmYerlbl01IDoCxTdyL//TyyPxbZEOQD5Q==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1305,14 +1396,15 @@
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.236.0.tgz",
-            "integrity": "sha512-W5vMEauWgFCzvf4Hks6ToU5dhbN87gyijmwp/l9AkKKvuJ25LkveAhk8xz3bydJThHdgWNEuBMyfmlVWmdybIg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.241.0.tgz",
+            "integrity": "sha512-CI+mu6h74Kzmscw35TvNkc/wYHsHPGAwP7humSHoWw53H9mVw21Ggft/dT1iFQQZWQ8BNXkzuXlNo1IlqwMgOA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1321,15 +1413,16 @@
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.236.0.tgz",
-            "integrity": "sha512-ktRPwmqw2P4dDzs/nJYTnuesSYqpDUEtqm2KSCKNT/fobzgfsrESLk3a7TY4l6N3muxQtKwguIa9Lulhe82+wg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.241.0.tgz",
+            "integrity": "sha512-08zPQcD5o9brQmzEipWHeHgU85aQcEF8MWLfpeyjO6e1/l7ysQ35NsS+PYtv77nLpGCx/X+ZuW/KXWoRrbw77w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/credential-provider-env": "3.226.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
-                "@aws-sdk/credential-provider-ini": "3.236.0",
+                "@aws-sdk/credential-provider-ini": "3.241.0",
                 "@aws-sdk/credential-provider-process": "3.226.0",
-                "@aws-sdk/credential-provider-sso": "3.236.0",
+                "@aws-sdk/credential-provider-sso": "3.241.0",
                 "@aws-sdk/credential-provider-web-identity": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1341,6 +1434,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.226.0.tgz",
             "integrity": "sha512-iUDMdnrTvbvaCFhWwqyXrhvQ9+ojPqPqXhwZtY1X/Qaz+73S9gXBPJHZaZb2Ke0yKE1Ql3bJbKvmmxC/qLQMng==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1349,14 +1443,15 @@
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.236.0.tgz",
-            "integrity": "sha512-HLeVsFHd8QLQwhjwhdlBhXOFIa33mzqmxOqe2Qr4FVD5IR1/G4zLpSWSwtYjpvWRZs2oWSg6XI7vSyeQttPmHg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.241.0.tgz",
+            "integrity": "sha512-6Bjd6eEIrVomRTrPrM4dlxusQm+KMJ9hLYKECCpFkwDKIK+pTgZNLRtQdalHyzwneHJPdimrm8cOv1kUQ8hPoA==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso": "3.236.0",
+                "@aws-sdk/client-sso": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
-                "@aws-sdk/token-providers": "3.236.0",
+                "@aws-sdk/token-providers": "3.241.0",
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
             }
@@ -1365,6 +1460,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.226.0.tgz",
             "integrity": "sha512-CCpv847rLB0SFOHz2igvUMFAzeT2fD3YnY4C8jltuJoEkn0ITn1Hlgt13nTJ5BUuvyti2mvyXZHmNzhMIMrIlw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1375,6 +1471,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.226.0.tgz",
             "integrity": "sha512-JewZPMNEBXfi1xVnRa7pVtK/zgZD8/lQ/YnD8pq79WuMa2cwyhDtr8oqCoqsPW+WJT5ScXoMtuHxN78l8eKWgg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/querystring-builder": "3.226.0",
@@ -1387,6 +1484,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.226.0.tgz",
             "integrity": "sha512-MdlJhJ9/Espwd0+gUXdZRsHuostB2WxEVAszWxobP0FTT9PnicqnfK7ExmW+DUAc0ywxtEbR3e0UND65rlSTVw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-buffer-from": "3.208.0",
@@ -1397,6 +1495,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.226.0.tgz",
             "integrity": "sha512-QXOYFmap8g9QzRjumcRCIo2GEZkdCwd7ePQW0OABWPhKHzlJ74vvBxywjU3s39EEBEluWXtZ7Iufg6GxZM4ifw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1406,6 +1505,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
             "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1414,6 +1514,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.226.0.tgz",
             "integrity": "sha512-ksUzlHJN2JMuyavjA46a4sctvnrnITqt2tbGGWWrAuXY1mel2j+VbgnmJUiwHKUO6bTFBBeft5Vd1TSOb4JmiA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1424,6 +1525,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.226.0.tgz",
             "integrity": "sha512-EvLFafjtUxTT0AC9p3aBQu1/fjhWdIeK58jIXaNFONfZ3F8QbEYUPuF/SqZvJM6cWfOO9qwYKkRDbCSTYhprIg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-serde": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1439,6 +1541,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.226.0.tgz",
             "integrity": "sha512-haVkWVh6BUPwKgWwkL6sDvTkcZWvJjv8AgC8jiQuSl8GLZdzHTB8Qhi3IsfFta9HAuoLjxheWBE5Z/L0UrfhLA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1449,6 +1552,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.226.0.tgz",
             "integrity": "sha512-m9gtLrrYnpN6yckcQ09rV7ExWOLMuq8mMPF/K3DbL/YL0TuILu9i2T1W+JuxSX+K9FMG2HrLAKivE/kMLr55xA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1458,6 +1562,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.226.0.tgz",
             "integrity": "sha512-mwRbdKEUeuNH5TEkyZ5FWxp6bL2UC1WbY+LDv6YjHxmSMKpAoOueEdtU34PqDOLrpXXxIGHDFmjeGeMfktyEcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1468,6 +1573,7 @@
             "version": "3.235.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.235.0.tgz",
             "integrity": "sha512-50WHbJGpD3SNp9763MAlHqIhXil++JdQbKejNpHg7HsJne/ao3ub+fDOfx//mMBjpzBV25BGd5UlfL6blrClSg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/service-error-classification": "3.229.0",
@@ -1482,6 +1588,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.226.0.tgz",
             "integrity": "sha512-NN9T/qoSD1kZvAT+VLny3NnlqgylYQcsgV3rvi/8lYzw/G/2s8VS6sm/VTWGGZhx08wZRv20MWzYu3bftcyqUg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-signing": "3.226.0",
                 "@aws-sdk/property-provider": "3.226.0",
@@ -1495,6 +1602,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.226.0.tgz",
             "integrity": "sha512-nPuOOAkSfx9TxzdKFx0X2bDlinOxGrqD7iof926K/AEflxGD1DBdcaDdjlYlPDW2CVE8LV/rAgbYuLxh/E/1VA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1504,6 +1612,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.226.0.tgz",
             "integrity": "sha512-E6HmtPcl+IjYDDzi1xI2HpCbBq2avNWcjvCriMZWuTAtRVpnA6XDDGW5GY85IfS3A8G8vuWqEVPr8JcYUcjfew==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1517,6 +1626,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.226.0.tgz",
             "integrity": "sha512-85wF29LvPvpoed60fZGDYLwv1Zpd/cM0C22WSSFPw1SSJeqO4gtFYyCg2squfT3KI6kF43IIkOCJ+L7GtryPug==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1525,6 +1635,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.226.0.tgz",
             "integrity": "sha512-N1WnfzCW1Y5yWhVAphf8OPGTe8Df3vmV7/LdsoQfmpkCZgLZeK2o0xITkUQhRj1mbw7yp8tVFLFV3R2lMurdAQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/protocol-http": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1535,6 +1646,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.226.0.tgz",
             "integrity": "sha512-B8lQDqiRk7X5izFEUMXmi8CZLOKCTWQJU9HQf3ako+sF0gexo4nHN3jhoRWyLtcgC5S3on/2jxpAcqtm7kuY3w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
@@ -1546,6 +1658,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.226.0.tgz",
             "integrity": "sha512-xQCddnZNMiPmjr3W7HYM+f5ir4VfxgJh37eqZwX6EZmyItFpNNeVzKUgA920ka1VPz/ZUYB+2OFGiX3LCLkkaA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/abort-controller": "3.226.0",
                 "@aws-sdk/protocol-http": "3.226.0",
@@ -1558,6 +1671,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.226.0.tgz",
             "integrity": "sha512-TsljjG+Sg0LmdgfiAlWohluWKnxB/k8xenjeozZfzOr5bHmNHtdbWv6BtNvD/R83hw7SFXxbJHlD5H4u9p2NFg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1567,6 +1681,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.226.0.tgz",
             "integrity": "sha512-zWkVqiTA9RXL6y0hhfZc9bcU4DX2NI6Hw9IhQmSPeM59mdbPjJlY4bLlMr5YxywqO3yQ/ylNoAfrEzrDjlOSRg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1576,6 +1691,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.226.0.tgz",
             "integrity": "sha512-LVurypuNeotO4lmirKXRC4NYrZRAyMJXuwO0f2a5ZAUJCjauwYrifKue6yCfU7bls7gut7nfcR6B99WBYpHs3g==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "@aws-sdk/util-uri-escape": "3.201.0",
@@ -1586,6 +1702,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.226.0.tgz",
             "integrity": "sha512-FzB+VrQ47KAFxiPt2YXrKZ8AOLZQqGTLCKHzx4bjxGmwgsjV8yIbtJiJhZLMcUQV4LtGeIY9ixIqQhGvnZHE4A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1594,12 +1711,14 @@
         "@aws-sdk/service-error-classification": {
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.229.0.tgz",
-            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg=="
+            "integrity": "sha512-dnzWWQ0/NoWMUZ5C0DW3dPm0wC1O76Y/SpKbuJzWPkx1EYy6r8p32Ly4D9vUzrKDbRGf48YHIF2kOkBmu21CLg==",
+            "dev": true
         },
         "@aws-sdk/shared-ini-file-loader": {
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.226.0.tgz",
             "integrity": "sha512-661VQefsARxVyyV2FX9V61V+nNgImk7aN2hYlFKla6BCwZfMng+dEtD0xVGyg1PfRw0qvEv5LQyxMVgHcUSevA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1609,6 +1728,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.226.0.tgz",
             "integrity": "sha512-/R5q5agdPd7HJB68XMzpxrNPk158EHUvkFkuRu5Qf3kkkHebEzWEBlWoVpUe6ss4rP9Tqcue6xPuaftEmhjpYw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1622,6 +1742,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.234.0.tgz",
             "integrity": "sha512-8AtR/k4vsFvjXeQbIzq/Wy7Nbk48Ou0wUEeVYPHWHPSU8QamFWORkOwmKtKMfHAyZvmqiAPeQqHFkq+UJhWyyQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/middleware-stack": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1629,11 +1750,12 @@
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.236.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.236.0.tgz",
-            "integrity": "sha512-gmHuWuQgl6+2UfdbOvtsns/byZQnPGjyQ88/SlKgnX2EcDd31ENb8wRa9gfIEwvx6rTB2ve1NAhuliydB9AomQ==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.241.0.tgz",
+            "integrity": "sha512-79okvuOS7V559OIL/RalIPG98wzmWxeFOChFnbEjn2pKOyGQ6FJRwLPYZaVRtNdAtnkBNgRpmFq9dX843QxhtQ==",
+            "dev": true,
             "requires": {
-                "@aws-sdk/client-sso-oidc": "3.236.0",
+                "@aws-sdk/client-sso-oidc": "3.241.0",
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/shared-ini-file-loader": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1644,6 +1766,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.226.0.tgz",
             "integrity": "sha512-MmmNHrWeO4man7wpOwrAhXlevqtOV9ZLcH4RhnG5LmRce0RFOApx24HoKENfFCcOyCm5LQBlsXCqi0dZWDWU0A==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1652,6 +1775,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.226.0.tgz",
             "integrity": "sha512-p5RLE0QWyP0OcTOLmFcLdVgUcUEzmEfmdrnOxyNzomcYb0p3vUagA5zfa1HVK2azsQJFBv28GfvMnba9bGhObg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/querystring-parser": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1662,6 +1786,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
             "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1671,6 +1796,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
             "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1679,6 +1805,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
             "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1687,6 +1814,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
             "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/is-array-buffer": "3.201.0",
                 "tslib": "^2.3.1"
@@ -1696,6 +1824,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
             "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1704,6 +1833,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.234.0.tgz",
             "integrity": "sha512-IHMKXjTbOD8XMz5+2oCOsVP94BYb9YyjXdns0aAXr2NAo7k2+RCzXQ2DebJXppGda1F6opFutoKwyVSN0cmbMw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/property-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1715,6 +1845,7 @@
             "version": "3.234.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.234.0.tgz",
             "integrity": "sha512-UGjQ+OjBYYhxFVtUY+jtr0ZZgzZh6OHtYwRhFt8IHewJXFCfZTyfsbX20szBj5y1S4HRIUJ7cwBLIytTqMbI5w==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/config-resolver": "3.234.0",
                 "@aws-sdk/credential-provider-imds": "3.226.0",
@@ -1725,9 +1856,10 @@
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.226.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.226.0.tgz",
-            "integrity": "sha512-iqOkac/zLmyPBUJd7SLN0PeZMkOmlGgD5PHmmekTClOkce2eUjK9SNX1PzL73aXPoPTyhg9QGLH8uEZEQ8YUzg==",
+            "version": "3.241.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.241.0.tgz",
+            "integrity": "sha512-jVf8bKrN22Ey0xLmj75sL7EUvm5HFpuOMkXsZkuXycKhCwLBcEUWlvtJYtRjOU1zScPQv9GMJd2QXQglp34iOQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "tslib": "^2.3.1"
@@ -1737,6 +1869,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
             "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1745,6 +1878,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
             "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1753,6 +1887,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.226.0.tgz",
             "integrity": "sha512-B96CQnwX4gRvQdaQkdUtqvDPkrptV5+va6FVeJOocU/DbSYMAScLxtR3peMS8cnlOT6nL1Eoa42OI9AfZz1VwQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1761,6 +1896,7 @@
             "version": "3.229.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.229.0.tgz",
             "integrity": "sha512-0zKTqi0P1inD0LzIMuXRIYYQ/8c1lWMg/cfiqUcIAF1TpatlpZuN7umU0ierpBFud7S+zDgg0oemh+Nj8xliJw==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/service-error-classification": "3.229.0",
                 "tslib": "^2.3.1"
@@ -1770,6 +1906,7 @@
             "version": "3.201.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
             "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1778,6 +1915,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.226.0.tgz",
             "integrity": "sha512-PhBIu2h6sPJPcv2I7ELfFizdl5pNiL4LfxrasMCYXQkJvVnoXztHA1x+CQbXIdtZOIlpjC+6BjDcE0uhnpvfcA==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/types": "3.226.0",
                 "bowser": "^2.11.0",
@@ -1788,6 +1926,7 @@
             "version": "3.226.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.226.0.tgz",
             "integrity": "sha512-othPc5Dz/pkYkxH+nZPhc1Al0HndQT8zHD4e9h+EZ+8lkd8n+IsnLfTS/mSJWrfiC6UlNRVw55cItstmJyMe/A==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/node-config-provider": "3.226.0",
                 "@aws-sdk/types": "3.226.0",
@@ -1798,6 +1937,7 @@
             "version": "3.188.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
             "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dev": true,
             "requires": {
                 "tslib": "^2.3.1"
             }
@@ -1806,6 +1946,7 @@
             "version": "3.208.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
             "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dev": true,
             "requires": {
                 "@aws-sdk/util-buffer-from": "3.208.0",
                 "tslib": "^2.3.1"
@@ -1814,12 +1955,14 @@
         "bowser": {
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+            "dev": true
         },
         "fast-xml-parser": {
             "version": "4.0.11",
             "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
             "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dev": true,
             "requires": {
                 "strnum": "^1.0.5"
             }
@@ -1827,17 +1970,20 @@
         "strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+            "dev": true
         },
         "tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+            "dev": true
         },
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         }
     }
 }

--- a/services/keyphrase/libs/web-socket-client-library/package.json
+++ b/services/keyphrase/libs/web-socket-client-library/package.json
@@ -2,7 +2,7 @@
     "name": "buzzword-keyphrase-web-socket-client-library",
     "version": "1.0.0",
     "main": "./index.js",
-    "dependencies": {
-        "@aws-sdk/client-apigatewaymanagementapi": "3.236.0"
+    "devDependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.241.0"
     }
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13,7 +13,7 @@
                 "@apollo/client": "3.6.9",
                 "@ashley-evans/buzzword-object-validator": "1.0.0",
                 "@aws-amplify/auth": "5.0.4",
-                "ajv": "8.8.2",
+                "ajv": "8.11.2",
                 "antd": "5.0.2",
                 "aws-appsync-auth-link": "3.0.7",
                 "aws-appsync-subscription-link": "3.1.1",
@@ -6459,9 +6459,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-            "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -23541,9 +23541,9 @@
             "requires": {}
         },
         "ajv": {
-            "version": "8.8.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-            "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
+            "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
                 "react": "18.1.0",
                 "react-dom": "18.1.0",
                 "react-router-dom": "6.3.0",
-                "rxjs": "7.5.5"
+                "rxjs": "7.8.0"
             },
             "devDependencies": {
                 "@babel/cli": "^7.17.10",
@@ -15876,9 +15876,9 @@
             "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
         },
         "node_modules/rxjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
             "dependencies": {
                 "tslib": "^2.1.0"
             }
@@ -30607,9 +30607,9 @@
             "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
         },
         "rxjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
             "requires": {
                 "tslib": "^2.1.0"
             }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,7 +17,7 @@
                 "antd": "5.0.2",
                 "aws-appsync-auth-link": "3.0.7",
                 "aws-appsync-subscription-link": "3.1.1",
-                "graphql": "16.5.0",
+                "graphql": "16.6.0",
                 "react": "18.1.0",
                 "react-dom": "18.1.0",
                 "react-router-dom": "6.3.0",
@@ -10375,9 +10375,9 @@
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "node_modules/graphql": {
-            "version": "16.5.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-            "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
+            "version": "16.6.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+            "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
@@ -26474,9 +26474,9 @@
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
         },
         "graphql": {
-            "version": "16.5.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-            "integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA=="
+            "version": "16.6.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+            "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
         },
         "graphql-tag": {
             "version": "2.12.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
         "antd": "5.0.2",
         "aws-appsync-auth-link": "3.0.7",
         "aws-appsync-subscription-link": "3.1.1",
-        "graphql": "16.5.0",
+        "graphql": "16.6.0",
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "react-router-dom": "6.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
         "react": "18.1.0",
         "react-dom": "18.1.0",
         "react-router-dom": "6.3.0",
-        "rxjs": "7.5.5"
+        "rxjs": "7.8.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.10",

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
         "@apollo/client": "3.6.9",
         "@ashley-evans/buzzword-object-validator": "1.0.0",
         "@aws-amplify/auth": "5.0.4",
-        "ajv": "8.8.2",
+        "ajv": "8.11.2",
         "antd": "5.0.2",
         "aws-appsync-auth-link": "3.0.7",
         "aws-appsync-subscription-link": "3.1.1",


### PR DESCRIPTION
# What

Update all references to Dynamoose to v3.1.0

Updated all aws-sdk dependencies to latest version and converted to dev dependency

Updated all references to rxjs to v7.4.0

Updated all references (except Object validator) to ajv to v8.11.2

Updated `CrawlStateMachineAdapter.ts` to provide `SUCCEEDED` status filter via string rather than referring to enum

Updated all references to dayjs to v1.11.7

# Why

aws-sdk dev dependency:
- v3 of the AWS SDK is now included in the node 18 runtime, therefore, we do not need to bundle these dependencies with the rest of the lambda's code

`SUCCEEDED` status:
- Received an error when the code is executed on AWS when referring to the enum
- Providing the `SUCCEEDED` status as a string resolves the issue and retains the functionality
