### PR TITLE
ci/ignore comment step dependabot

### DIFF
--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -91,7 +91,7 @@ jobs:
     add-changeset-comment:
         runs-on: ubuntu-latest
         needs: deploy-dryrun
-        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' && github.actor != 'dependabot[bot]' }}
         steps:
             - uses: actions/checkout@v3
             - name: Find Comment

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -84,7 +84,7 @@ jobs:
     add-changeset-comment:
         runs-on: ubuntu-latest
         needs: deploy-dryrun
-        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' && github.actor != 'dependabot[bot]' }}
         steps:
             - uses: actions/checkout@v3
             - name: Find Comment


### PR DESCRIPTION
# What

Update add-changeset-command jobs to not run for dependabot PRs

# Why

This job is currently failing on dependabot PRs, this is because dependabot PRs by default `read` access to the repository and thus cannot create comments on PRs.

There are security considerations with providing this access as discussed here: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Updating the workflows to allow dependabot PRs to add changeset comments would add a lot of overhead for very little value. Therefore, simply disabling this behaviour on these PRs resolves this issue