### PR TITLE
ci/prevent deploy dryrun dependabot

### DIFF
--- a/.github/workflows/service-build.yml
+++ b/.github/workflows/service-build.yml
@@ -13,13 +13,41 @@ on:
             service_name:
                 required: true
                 type: string
+            dryrun:
+                required: true
+                type: boolean
         secrets:
             deploy_role:
                 required: true
 
 jobs:
+    compile:
+        runs-on: ubuntu-latest
+        if: ${{ !inputs.dryrun }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
+                  scope: "@ashley-evans"
+                  registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
+            - name: Compile Package
+              run: |
+                  ./scripts/helpers/compile-service.sh -c -p ${{ inputs.path }}
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     deploy-dryrun:
         runs-on: ubuntu-latest
+        if: ${{ inputs.dryrun }}
         permissions:
             id-token: write
             contents: read
@@ -74,7 +102,7 @@ jobs:
     add-changeset-comment:
         runs-on: ubuntu-latest
         needs: deploy-dryrun
-        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' && github.actor != 'dependabot[bot]' }}
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
         steps:
             - uses: actions/checkout@v3
             - name: Find Comment

--- a/.github/workflows/service-build.yml
+++ b/.github/workflows/service-build.yml
@@ -1,0 +1,104 @@
+on:
+    workflow_call:
+        inputs:
+            service_cache_key:
+                required: true
+                type: string
+            path:
+                required: true
+                type: string
+            deploy_script_path:
+                required: true
+                type: string
+            service_name:
+                required: true
+                type: string
+        secrets:
+            deploy_role:
+                required: true
+
+jobs:
+    deploy-dryrun:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+            packages: read
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.8"
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
+                  scope: "@ashley-evans"
+                  registry-url: "https://npm.pkg.github.com"
+            - uses: aws-actions/setup-sam@v2
+            - uses: aws-actions/configure-aws-credentials@v1-node16
+              with:
+                  aws-region: eu-west-2
+                  role-to-assume: ${{ secrets.deploy_role }}
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ${{ inputs.path }}/**/node_modules
+                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
+            - name: Cache deployment packages
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      .aws-sam/cache/**
+                      .aws-sam/deps/**
+                      .aws-sam/build.toml
+                  key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
+                  restore-keys: |
+                      ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-
+            - name: Dry Run Deployment
+              id: dry-run
+              run: |
+                  ./scripts/helpers/write-changeset-to-file.sh -c "${{ inputs.deploy_script_path }} -e production -d" \
+                    -f $GITHUB_OUTPUT \
+                    -v CHANGESET_OUTPUT \
+                    -d EOF
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        outputs:
+            CHANGESET_OUTPUT: ${{ steps.dry-run.outputs.CHANGESET_OUTPUT }}
+    add-changeset-comment:
+        runs-on: ubuntu-latest
+        needs: deploy-dryrun
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' && github.actor != 'dependabot[bot]' }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: ${{ inputs.service_name }}
+            - name: Create Multiline changeset YAML variable for template
+              run: |
+                  ./scripts/helpers/multiline-string-to-yml.sh -k changeset \
+                    -v "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}" \
+                    -o ./template_vars.yml
+            - name: Create comment template
+              uses: chuhlomin/render-template@v1.6
+              id: template
+              with:
+                  template: .github/comment_template/changeset-template.md
+                  vars: |
+                      service_name: "${{ inputs.service_name }}"
+                  vars_path: ./template_vars.yml
+            - name: Create or update comment
+              uses: peter-evans/create-or-update-comment@v2
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: ${{ steps.template.outputs.result }}
+                  edit-mode: replace

--- a/.github/workflows/service-build.yml
+++ b/.github/workflows/service-build.yml
@@ -35,6 +35,8 @@ jobs:
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
             - uses: aws-actions/setup-sam@v2
+            - name: Fix SAM Cryptography
+              run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
             - uses: aws-actions/configure-aws-credentials@v1-node16
               with:
                   aws-region: eu-west-2

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -35,92 +35,6 @@ jobs:
                       service:
                           - ${{ inputs.path }}/**
                           - ./.github/workflows/service.yml
-    deploy-dryrun:
-        runs-on: ubuntu-latest
-        needs: changed
-        if: ${{ needs.changed.outputs.service == 'true' }}
-        permissions:
-            id-token: write
-            contents: read
-            packages: read
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
-              with:
-                  python-version: "3.8"
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "18"
-                  scope: "@ashley-evans"
-                  registry-url: "https://npm.pkg.github.com"
-            - uses: aws-actions/setup-sam@v2
-            - uses: aws-actions/configure-aws-credentials@v1-node16
-              with:
-                  aws-region: eu-west-2
-                  role-to-assume: ${{ secrets.deploy_role }}
-            - name: Cache Node Dependencies
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      ./node_modules
-                      ${{ inputs.path }}/**/node_modules
-                  key: ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path), './package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-v1-${{ inputs.service_cache_key }}-
-            - name: Cache deployment packages
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      .aws-sam/cache/**
-                      .aws-sam/deps/**
-                      .aws-sam/build.toml
-                  key: ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-${{ hashFiles(format('{0}/**/package-lock.json', inputs.path)) }}
-                  restore-keys: |
-                      ${{ runner.os }}-deploy-${{ inputs.service_cache_key }}-v1-${{ env.deployment_cache_name }}-
-            - name: Dry Run Deployment
-              id: dry-run
-              run: |
-                  ./scripts/helpers/write-changeset-to-file.sh -c "${{ inputs.deploy_script_path }} -e production -d" \
-                    -f $GITHUB_OUTPUT \
-                    -v CHANGESET_OUTPUT \
-                    -d EOF
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        outputs:
-            CHANGESET_OUTPUT: ${{ steps.dry-run.outputs.CHANGESET_OUTPUT }}
-    add-changeset-comment:
-        runs-on: ubuntu-latest
-        needs: deploy-dryrun
-        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' && github.actor != 'dependabot[bot]' }}
-        steps:
-            - uses: actions/checkout@v3
-            - name: Find Comment
-              uses: peter-evans/find-comment@v2
-              id: find-comment
-              with:
-                  issue-number: ${{ github.event.pull_request.number }}
-                  comment-author: "github-actions[bot]"
-                  body-includes: ${{ inputs.service_name }}
-            - name: Create Multiline changeset YAML variable for template
-              run: |
-                  ./scripts/helpers/multiline-string-to-yml.sh -k changeset \
-                    -v "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}" \
-                    -o ./template_vars.yml
-            - name: Create comment template
-              uses: chuhlomin/render-template@v1.6
-              id: template
-              with:
-                  template: .github/comment_template/changeset-template.md
-                  vars: |
-                      service_name: "${{ inputs.service_name }}"
-                  vars_path: ./template_vars.yml
-            - name: Create or update comment
-              uses: peter-evans/create-or-update-comment@v2
-              with:
-                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
-                  issue-number: ${{ github.event.pull_request.number }}
-                  body: ${{ steps.template.outputs.result }}
-                  edit-mode: replace
     audit:
         runs-on: ubuntu-latest
         steps:
@@ -135,6 +49,17 @@ jobs:
                   ./scripts/helpers/npm-all.sh -c "audit --audit-level=high" -r ${{ inputs.path }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    build:
+        uses: ./.github/workflows/service-build.yml
+        needs: changed
+        if: ${{ needs.changed.outputs.service == 'true' }}
+        with:
+            service_cache_key: ${{ inputs.service_cache_key }}
+            path: ${{ inputs.path }}
+            deploy_script_path: ${{ inputs.deploy_script_path }}
+            service_name: ${{ inputs.service_name }}
+        secrets:
+            deploy_role: ${{ secrets.deploy_role }}
     format:
         runs-on: ubuntu-latest
         needs: changed
@@ -259,15 +184,7 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         needs:
-            [
-                deploy-dryrun,
-                audit,
-                format,
-                lint,
-                validate,
-                unit-test,
-                integration-test,
-            ]
+            [build, audit, format, lint, validate, unit-test, integration-test]
         if: ${{ github.ref == 'refs/heads/master' }}
         permissions:
             id-token: write

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -58,6 +58,7 @@ jobs:
             path: ${{ inputs.path }}
             deploy_script_path: ${{ inputs.deploy_script_path }}
             service_name: ${{ inputs.service_name }}
+            dryrun: ${{ github.actor != 'dependabot[bot]' }}
         secrets:
             deploy_role: ${{ secrets.deploy_role }}
     format:

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -201,6 +201,8 @@ jobs:
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
             - uses: aws-actions/setup-sam@v2
+            - name: Fix SAM Cryptography
+              run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
             - uses: aws-actions/configure-aws-credentials@v1-node16
               with:
                   aws-region: eu-west-2

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -1,0 +1,112 @@
+on:
+    workflow_call:
+        inputs:
+            dryrun:
+                required: true
+                type: boolean
+        secrets:
+            DEPLOY_ROLE:
+                required: true
+
+jobs:
+    bundle:
+        runs-on: ubuntu-latest
+        if: ${{ !inputs.dryrun }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
+                  scope: "@ashley-evans"
+                  registry-url: "https://npm.pkg.github.com"
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
+            - name: Build UI
+              run: |
+                  npm --prefix ${{ inputs.path }} run build
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    deploy-dryrun:
+        runs-on: ubuntu-latest
+        if: ${{ inputs.dryrun }}
+        permissions:
+            id-token: write
+            contents: read
+            packages: read
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.8"
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: "18"
+                  scope: "@ashley-evans"
+                  registry-url: "https://npm.pkg.github.com"
+            - uses: aws-actions/setup-sam@v2
+            - name: Fix SAM Cryptography
+              run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
+            - uses: aws-actions/configure-aws-credentials@v1-node16
+              with:
+                  aws-region: eu-west-2
+                  role-to-assume: ${{ secrets.DEPLOY_ROLE }}
+            - name: Cache Node Dependencies
+              uses: actions/cache@v3
+              with:
+                  path: |
+                      ./node_modules
+                      ./ui/node_modules
+                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-v1-ui-
+            - name: Dry Run Deployment
+              id: dry-run
+              run: |
+                  ./scripts/helpers/write-changeset-to-file.sh -c "./scripts/deploy-ui.sh -e production -d -c" \
+                    -f $GITHUB_OUTPUT \
+                    -v CHANGESET_OUTPUT \
+                    -d EOF
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        outputs:
+            CHANGESET_OUTPUT: ${{ steps.dry-run.outputs.CHANGESET_OUTPUT }}
+    add-changeset-comment:
+        runs-on: ubuntu-latest
+        needs: deploy-dryrun
+        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Find Comment
+              uses: peter-evans/find-comment@v2
+              id: find-comment
+              with:
+                  issue-number: ${{ github.event.pull_request.number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: "How Many Buzzwords UI"
+            - name: Create Multiline changeset YAML variable for template
+              run: |
+                  ./scripts/helpers/multiline-string-to-yml.sh -k changeset \
+                    -v "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}" \
+                    -o ./template_vars.yml
+            - name: Create comment template
+              uses: chuhlomin/render-template@v1.6
+              id: template
+              with:
+                  template: .github/comment_template/changeset-template.md
+                  vars: |
+                      service_name: "How Many Buzzwords UI"
+                  vars_path: ./template_vars.yml
+            - name: Create or update comment
+              uses: peter-evans/create-or-update-comment@v2
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ github.event.pull_request.number }}
+                  body: ${{ steps.template.outputs.result }}
+                  edit-mode: replace

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -38,82 +38,14 @@ jobs:
                   npm audit --audit-level=critical --prefix ${{ inputs.path }}
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    deploy-dryrun:
-        runs-on: ubuntu-latest
+    build:
+        uses: ./.github/workflows/ui-build.yml
         needs: changed
         if: ${{ needs.changed.outputs.ui == 'true' }}
-        permissions:
-            id-token: write
-            contents: read
-            packages: read
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-python@v4
-              with:
-                  python-version: "3.8"
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "18"
-                  scope: "@ashley-evans"
-                  registry-url: "https://npm.pkg.github.com"
-            - uses: aws-actions/setup-sam@v2
-            - uses: aws-actions/configure-aws-credentials@v1-node16
-              with:
-                  aws-region: eu-west-2
-                  role-to-assume: ${{ secrets.DEPLOY_ROLE }}
-            - name: Cache Node Dependencies
-              uses: actions/cache@v3
-              with:
-                  path: |
-                      ./node_modules
-                      ./ui/node_modules
-                  key: ${{ runner.os }}-node-v1-ui-${{ hashFiles('./package-lock.json', './ui/package-lock.json') }}
-                  restore-keys: |
-                      ${{ runner.os }}-node-v1-ui-
-            - name: Dry Run Deployment
-              id: dry-run
-              run: |
-                  ./scripts/helpers/write-changeset-to-file.sh -c "./scripts/deploy-ui.sh -e production -d -c" \
-                    -f $GITHUB_OUTPUT \
-                    -v CHANGESET_OUTPUT \
-                    -d EOF
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        outputs:
-            CHANGESET_OUTPUT: ${{ steps.dry-run.outputs.CHANGESET_OUTPUT }}
-    add-changeset-comment:
-        runs-on: ubuntu-latest
-        needs: deploy-dryrun
-        if: ${{ github.event_name == 'pull_request' && needs.deploy-dryrun.outputs.CHANGESET_OUTPUT != '' && github.actor != 'dependabot[bot]' }}
-        steps:
-            - uses: actions/checkout@v3
-            - name: Find Comment
-              uses: peter-evans/find-comment@v2
-              id: find-comment
-              with:
-                  issue-number: ${{ github.event.pull_request.number }}
-                  comment-author: "github-actions[bot]"
-                  body-includes: "How Many Buzzwords UI"
-            - name: Create Multiline changeset YAML variable for template
-              run: |
-                  ./scripts/helpers/multiline-string-to-yml.sh -k changeset \
-                    -v "${{ needs.deploy-dryrun.outputs.CHANGESET_OUTPUT }}" \
-                    -o ./template_vars.yml
-            - name: Create comment template
-              uses: chuhlomin/render-template@v1.6
-              id: template
-              with:
-                  template: .github/comment_template/changeset-template.md
-                  vars: |
-                      service_name: "How Many Buzzwords UI"
-                  vars_path: ./template_vars.yml
-            - name: Create or update comment
-              uses: peter-evans/create-or-update-comment@v2
-              with:
-                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
-                  issue-number: ${{ github.event.pull_request.number }}
-                  body: ${{ steps.template.outputs.result }}
-                  edit-mode: replace
+        with:
+            dryrun: ${{ github.actor != 'dependabot[bot]' }}
+        secrets:
+            DEPLOY_ROLE: ${{ secrets.DEPLOY_ROLE }}
     format:
         runs-on: ubuntu-latest
         needs: changed
@@ -227,15 +159,7 @@ jobs:
                   retention-days: 5
     deploy:
         runs-on: ubuntu-latest
-        needs:
-            [
-                audit,
-                deploy-dryrun,
-                format,
-                lint,
-                unit-test,
-                browser-component-test,
-            ]
+        needs: [audit, build, format, lint, unit-test, browser-component-test]
         if: ${{ github.ref == 'refs/heads/master' }}
         permissions:
             id-token: write
@@ -252,6 +176,8 @@ jobs:
                   scope: "@ashley-evans"
                   registry-url: "https://npm.pkg.github.com"
             - uses: aws-actions/setup-sam@v2
+            - name: Fix SAM Cryptography
+              run: $(dirname $(readlink $(which sam)))/pip install --force-reinstall "cryptography==38.0.4"
             - uses: aws-actions/configure-aws-credentials@v1-node16
               with:
                   aws-region: eu-west-2


### PR DESCRIPTION
# What

Updated `service.yml` and `ui.yml` to only run deployment dry runs on non dependabot builds
- Dependabot builds only trigger bundle/compile rather than using SAM

Updated all usages of SAM to reinstall `cryptography-38.0.4` before running any SAM commands

# Why

Dependabot SAM Dry Runs:
- For the SAM deployment to occur we need to give the runner permission to deploy resources to AWS. This requires giving id-token write permission to dependabot builds which by default is not provided as a malicious dependency could use this permission to perform actions, [see here](https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544)
    - Therefore, removed this step for dependabot to match that default

SAM Crytography:
- There is a current issue with the setup-sam action, [see here](https://github.com/aws-actions/setup-sam/issues/64)