### PR TITLE
ci/575 replace npm audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,17 +95,3 @@ jobs:
               run: |
                   ./node_modules/.bin/eslint '.' --max-warnings 0 --ext .js,.jsx,.ts,.tsx --ignore-pattern 'services/**' --ignore-pattern 'packages/**' --ignore-pattern 'ui/**'
                   ./node_modules/.bin/npmPkgJsonLint ./package.json
-    audit:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "18"
-                  scope: "@ashley-evans"
-                  registry-url: "https://npm.pkg.github.com"
-            - name: Audit Dependencies
-              run: |
-                  npm audit --audit-level=critical
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,16 +44,6 @@ jobs:
             - name: Compile Package
               run: |
                   ./scripts/helpers/compile-package.sh -c -p ${{ inputs.path }}
-    audit:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "18"
-            - name: Audit Dependencies
-              run: |
-                  npm audit --prefix ${{ inputs.path }}
     format:
         runs-on: ubuntu-latest
         needs: changed
@@ -121,7 +111,7 @@ jobs:
                   ./node_modules/.bin/jest --testPathPattern=${{ inputs.path }} --verbose --max-workers ${{ steps.cpu-cores.outputs.count }}
     publish:
         runs-on: ubuntu-latest
-        needs: [compile, audit, format, lint, unit-test]
+        needs: [compile, format, lint, unit-test]
         if: ${{ github.ref == 'refs/heads/master' }}
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/service.yml
+++ b/.github/workflows/service.yml
@@ -35,20 +35,6 @@ jobs:
                       service:
                           - ${{ inputs.path }}/**
                           - ./.github/workflows/service.yml
-    audit:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "18"
-                  scope: "@ashley-evans"
-                  registry-url: "https://npm.pkg.github.com"
-            - name: Audit Dependencies
-              run: |
-                  ./scripts/helpers/npm-all.sh -c "audit --audit-level=high" -r ${{ inputs.path }}
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     build:
         uses: ./.github/workflows/service-build.yml
         needs: changed
@@ -184,8 +170,7 @@ jobs:
                   npm run test:integration -- --testPathPattern=${{ inputs.path }} --max-workers ${{ steps.cpu-cores.outputs.count }}
     deploy:
         runs-on: ubuntu-latest
-        needs:
-            [build, audit, format, lint, validate, unit-test, integration-test]
+        needs: [build, format, lint, validate, unit-test, integration-test]
         if: ${{ github.ref == 'refs/heads/master' }}
         permissions:
             id-token: write

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -24,20 +24,6 @@ jobs:
                         - ${{ inputs.path }}/**
                         - ./.github/workflows/ui.yml
                         - ./scripts/deploy-ui.sh
-    audit:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: "18"
-                  scope: "@ashley-evans"
-                  registry-url: "https://npm.pkg.github.com"
-            - name: Audit Dependencies
-              run: |
-                  npm audit --audit-level=critical --prefix ${{ inputs.path }}
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     build:
         uses: ./.github/workflows/ui-build.yml
         needs: changed
@@ -160,7 +146,7 @@ jobs:
                   retention-days: 5
     deploy:
         runs-on: ubuntu-latest
-        needs: [audit, build, format, lint, unit-test, browser-component-test]
+        needs: [build, format, lint, unit-test, browser-component-test]
         if: ${{ github.ref == 'refs/heads/master' }}
         permissions:
             id-token: write

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint
-npm run audit:parallel
 npm run format:check

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
         "yargs": "^17.3.1"
     },
     "scripts": {
-        "audit:sequential": "./scripts/helpers/npm-all.sh -c \"audit --audit-level=critical\"",
-        "audit:parallel": "./scripts/helpers/npm-all.sh -c \"audit --audit-level=critical\" -p",
         "lint-js": "node node_modules/.bin/eslint '.' --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
         "lint-packages": "node node_modules/.bin/npmPkgJsonLint '.'",
         "lint": "npm run lint-js && npm run lint-packages",


### PR DESCRIPTION
Resolves #575 

# What

Remove all references to `npm audit` from project

# Why

Using `npm audit` to manage security vulnerabilities was very cumbersome. GitHub Dependabot Security alerts have been enabled for the project and PRs will be created if any issues are found. This should provide the same value.